### PR TITLE
Add Nitro and Nuxt integration entries

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -1,0 +1,27 @@
+# Safe Runtime Config
+
+This context defines the project language for validating Nuxt and Nitro runtime configuration.
+
+## Language
+
+**Runtime validation**:
+Validation of the resolved server runtime config when Nitro starts.
+_Avoid_: startup validation, server validation
+
+**Build validation**:
+Validation of configured runtime config during Nuxt or Nitro build hooks.
+_Avoid_: compile-time validation, static validation
+
+## Relationships
+
+- **Runtime validation** happens after runtime environment values have been resolved.
+- **Build validation** happens before the server starts.
+
+## Example dialogue
+
+> **Dev:** "Should this failure be handled by **Build validation**?"
+> **Domain expert:** "No, it depends on the server's resolved environment, so it belongs to **Runtime validation**."
+
+## Flagged ambiguities
+
+- "runtime validation" means validation when Nitro starts, not validation inside the Vue app runtime.

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist
 *.tgz
 
 # Nuxt
+.nitro
 .nuxt
 .output
 .nuxtrc

--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ Runtime validation uses [@cfworker/json-schema](https://github.com/cfworker/cfwo
 - Missing required environment variables in production
 - Invalid values that pass build-time checks but fail at runtime
 
+Shelve runtime fetching is separate from validation ownership. If `shelve.fetchAtRuntime` is enabled, the Shelve runtime plugin runs before validation so fetched secrets are included in the validated config.
+
 ## ESLint Integration
 
 The module includes an ESLint plugin that warns when using `useRuntimeConfig()` instead of `useSafeRuntimeConfig()`.

--- a/build.config.ts
+++ b/build.config.ts
@@ -1,9 +1,12 @@
 import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
-  entries: [{ input: 'src/eslint/index', name: 'eslint' }],
+  entries: [
+    { input: 'src/nitro', name: 'nitro' },
+    { input: 'src/eslint/index', name: 'eslint' },
+  ],
   declaration: true,
   clean: false,
   rollup: { emitCJS: false },
-  externals: ['@typescript-eslint/utils', '@typescript-eslint/types', 'eslint'],
+  externals: ['@nuxt/kit', '@typescript-eslint/utils', '@typescript-eslint/types', 'eslint'],
 })

--- a/docs/content/1.guide/4.validation.md
+++ b/docs/content/1.guide/4.validation.md
@@ -5,12 +5,14 @@ icon: ph:seal-check
 
 The module validates your runtime config to catch configuration errors early. By default, validation runs at build time only.
 
+Validation is handled by the package's Nitro module. In Nuxt apps, the Nuxt module exposes the user-facing API, types, and imports, then passes validation options into Nitro. Generated validation files are internal implementation details and their paths are not part of the public API.
+
 ## Build-time Validation (Default)
 
-With default settings, validation runs at:
+With default settings, build validation runs through Nitro during:
 
 - **Dev start** - when running `nuxt dev`
-- **Build completion** - when running `nuxt build`
+- **Build** - when running `nuxt build`
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -53,6 +55,8 @@ When enabled:
 1. Module generates JSON Schema from your Standard Schema
 2. A Nitro plugin validates `useRuntimeConfig()` on cold start
 3. Uses [@cfworker/json-schema](https://github.com/cfworker/cfworker/tree/main/packages/json-schema) (~8KB, edge-compatible)
+
+Shelve runtime fetching remains a separate integration. When `shelve.fetchAtRuntime` is enabled, that runtime fetch plugin runs before validation so fetched secrets can be validated.
 
 What it catches:
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,5 +13,8 @@ export default antfu({
     'playground/shelve.json',
     'src/runtime/**/*.d.ts',
     'src/runtime/**/*.js',
+    'test/fixtures/**/.nitro/**',
+    'test/fixtures/**/.nuxt/**',
+    'test/fixtures/**/.output/**',
   ],
 })

--- a/package.json
+++ b/package.json
@@ -25,12 +25,16 @@
   "sideEffects": false,
   "exports": {
     ".": { "types": "./dist/types.d.mts", "import": "./dist/module.mjs" },
+    "./nuxt": { "types": "./dist/types.d.mts", "import": "./dist/module.mjs" },
+    "./nitro": { "types": "./dist/nitro.d.mts", "import": "./dist/nitro.mjs" },
     "./eslint": { "types": "./dist/eslint.d.mts", "import": "./dist/eslint.mjs" }
   },
   "main": "./dist/module.mjs",
   "typesVersions": {
     "*": {
       ".": ["./dist/types.d.mts"],
+      "nuxt": ["./dist/types.d.mts"],
+      "nitro": ["./dist/nitro.d.mts"],
       "eslint": ["./dist/eslint.d.mts"]
     }
   },
@@ -56,10 +60,13 @@
   },
   "peerDependencies": {
     "@nuxt/kit": "^3.0.0 || ^4.0.0 || ^5.0.0-0",
-    "eslint": ">=9.0.0"
+    "eslint": ">=9.0.0",
+    "nitropack": "^2.0.0"
   },
   "peerDependenciesMeta": {
-    "eslint": { "optional": true }
+    "@nuxt/kit": { "optional": true },
+    "eslint": { "optional": true },
+    "nitropack": { "optional": true }
   },
   "dependencies": {
     "@cfworker/json-schema": "catalog:",

--- a/package.json
+++ b/package.json
@@ -24,18 +24,38 @@
   ],
   "sideEffects": false,
   "exports": {
-    ".": { "types": "./dist/types.d.mts", "import": "./dist/module.mjs" },
-    "./nuxt": { "types": "./dist/types.d.mts", "import": "./dist/module.mjs" },
-    "./nitro": { "types": "./dist/nitro.d.mts", "import": "./dist/nitro.mjs" },
-    "./eslint": { "types": "./dist/eslint.d.mts", "import": "./dist/eslint.mjs" }
+    ".": {
+      "types": "./dist/types.d.mts",
+      "import": "./dist/module.mjs"
+    },
+    "./nuxt": {
+      "types": "./dist/types.d.mts",
+      "import": "./dist/module.mjs"
+    },
+    "./nitro": {
+      "types": "./dist/nitro.d.mts",
+      "import": "./dist/nitro.mjs"
+    },
+    "./eslint": {
+      "types": "./dist/eslint.d.mts",
+      "import": "./dist/eslint.mjs"
+    }
   },
   "main": "./dist/module.mjs",
   "typesVersions": {
     "*": {
-      ".": ["./dist/types.d.mts"],
-      "nuxt": ["./dist/types.d.mts"],
-      "nitro": ["./dist/nitro.d.mts"],
-      "eslint": ["./dist/eslint.d.mts"]
+      ".": [
+        "./dist/types.d.mts"
+      ],
+      "nuxt": [
+        "./dist/types.d.mts"
+      ],
+      "nitro": [
+        "./dist/nitro.d.mts"
+      ],
+      "eslint": [
+        "./dist/eslint.d.mts"
+      ]
     }
   },
   "files": [
@@ -61,12 +81,18 @@
   "peerDependencies": {
     "@nuxt/kit": "^3.0.0 || ^4.0.0 || ^5.0.0-0",
     "eslint": ">=9.0.0",
-    "nitropack": "^2.0.0"
+    "nitro": "^3.0.0-beta"
   },
   "peerDependenciesMeta": {
-    "@nuxt/kit": { "optional": true },
-    "eslint": { "optional": true },
-    "nitropack": { "optional": true }
+    "@nuxt/kit": {
+      "optional": true
+    },
+    "eslint": {
+      "optional": true
+    },
+    "nitro": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@cfworker/json-schema": "catalog:",
@@ -99,6 +125,7 @@
     "eslint": "catalog:",
     "eslint-plugin-format": "catalog:",
     "lint-staged": "catalog:",
+    "nitro": "catalog:",
     "nuxt": "catalog:",
     "simple-git-hooks": "catalog:",
     "typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       magicast:
         specifier: 'catalog:'
         version: 0.3.5
+      nitropack:
+        specifier: ^2.0.0
+        version: 2.13.1(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)
       ofetch:
         specifier: 'catalog:'
         version: 1.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ catalogs:
     magicast:
       specifier: ^0.3.5
       version: 0.3.5
+    nitro:
+      specifier: 3.0.260429-beta
+      version: 3.0.260429-beta
     nuxt:
       specifier: ^4.4.2
       version: 4.4.2
@@ -152,9 +155,6 @@ importers:
       magicast:
         specifier: 'catalog:'
         version: 0.3.5
-      nitropack:
-        specifier: ^2.0.0
-        version: 2.13.1(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)
       ofetch:
         specifier: 'catalog:'
         version: 1.4.1
@@ -216,9 +216,12 @@ importers:
       lint-staged:
         specifier: 'catalog:'
         version: 16.1.0
+      nitro:
+        specifier: 'catalog:'
+        version: 3.0.260429-beta(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@17.2.3)(giget@3.1.2)(jiti@2.6.1)(rollup@4.41.1)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2)
       simple-git-hooks:
         specifier: 'catalog:'
         version: 2.13.0
@@ -248,10 +251,10 @@ importers:
         version: 12.8.0
       docus:
         specifier: catalog:default
-        version: 5.8.1(lm5hnwzjdjozjmwueejgquhx54)
+        version: 5.8.1(f632owwsyx6xoqwovimq3l4zhu)
       nuxt:
         specifier: catalog:default
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -266,7 +269,7 @@ importers:
         version: 1.3.0(valibot@1.1.0(typescript@5.9.3))
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
       valibot:
         specifier: 'catalog:'
         version: 1.1.0(typescript@5.9.3)
@@ -279,7 +282,7 @@ importers:
     devDependencies:
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
 
   test/fixtures/cloudflare-auto-import:
     dependencies:
@@ -289,13 +292,13 @@ importers:
     devDependencies:
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
 
   test/fixtures/no-config:
     devDependencies:
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
 
   test/fixtures/runtime-invalid:
     dependencies:
@@ -305,7 +308,7 @@ importers:
     devDependencies:
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
 
   test/fixtures/server-typing:
     dependencies:
@@ -315,13 +318,13 @@ importers:
     devDependencies:
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
 
   test/fixtures/shelve-integration:
     devDependencies:
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
 
   test/fixtures/valibot-runtime:
     dependencies:
@@ -331,7 +334,7 @@ importers:
     devDependencies:
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
 
   test/fixtures/validation-failure:
     dependencies:
@@ -341,7 +344,7 @@ importers:
     devDependencies:
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
 
   test/fixtures/validation-success:
     dependencies:
@@ -351,7 +354,7 @@ importers:
     devDependencies:
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
 
   test/fixtures/zod-native:
     dependencies:
@@ -361,7 +364,7 @@ importers:
     devDependencies:
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
 
 packages:
 
@@ -671,14 +674,23 @@ packages:
   '@dxup/unimport@0.1.2':
     resolution: {integrity: sha512-/B8YJGPzaYq1NbsQmwgP8EZqg40NpTw4ZB3suuI0TplbxKHeK94jeaawLmVhCv+YwUnOpiWEz9U6SeThku/8JQ==}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@es-joy/jsdoccomment@0.50.2':
     resolution: {integrity: sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==}
@@ -1576,6 +1588,12 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@netlify/blobs@9.1.2':
     resolution: {integrity: sha512-7dMjExSH4zj4ShvLem49mE3mf0K171Tx2pV4WDWhJbRUWW3SJIR2qntz0LvUGS97N5HO1SmnzrgWUhEXCsApiw==}
     engines: {node: ^14.16.0 || >=16.0.0}
@@ -2222,6 +2240,9 @@ packages:
   '@oxc-project/types@0.117.0':
     resolution: {integrity: sha512-C/kPXBphID44fXdsa2xSOCuzX8fKZiFxPsvucJ6Yfkr6CJlMA+kNLPNKyLoI+l9XlDsNxBrz6h7IIjKU8pB69w==}
 
+  '@oxc-project/types@0.128.0':
+    resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
+
   '@oxc-project/types@0.95.0':
     resolution: {integrity: sha512-vACy7vhpMPhjEJhULNxrdR0D943TkA/MigMpJCHmBHvMXxRStRi/dPtTlfQ3uDwWSzRpT8z+7ImjZVf8JWBocQ==}
 
@@ -2627,6 +2648,98 @@ packages:
   '@resvg/resvg-wasm@2.6.2':
     resolution: {integrity: sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw==}
     engines: {node: '>= 10'}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+    resolution: {integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    resolution: {integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.18':
+    resolution: {integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==}
 
   '@rolldown/pluginutils@1.0.0-rc.2':
     resolution: {integrity: sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==}
@@ -4603,6 +4716,14 @@ packages:
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
+  crossws@0.4.5:
+    resolution: {integrity: sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA==}
+    peerDependencies:
+      srvx: '>=0.11.5'
+    peerDependenciesMeta:
+      srvx:
+        optional: true
+
   css-background-parser@0.1.0:
     resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
 
@@ -4975,6 +5096,18 @@ packages:
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  env-runner@0.1.7:
+    resolution: {integrity: sha512-i7h96jxETJYhXy5grgHNJ9xNzCzWIn9Ck/VkkYgOlE4gOqknsLX3CmlVb5LmwNex8sOoLFVZLz+TIw/+b5rktA==}
+    hasBin: true
+    peerDependencies:
+      '@netlify/runtime': ^4
+      miniflare: ^4.20260317.3
+    peerDependenciesMeta:
+      '@netlify/runtime':
+        optional: true
+      miniflare:
+        optional: true
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -5635,6 +5768,16 @@ packages:
   h3@1.15.6:
     resolution: {integrity: sha512-oi15ESLW5LRthZ+qPCi5GNasY/gvynSKUQxgiovrY63bPAtG59wtM+LSrlcwvOHAXzGrXVLnI97brbkdPF9WoQ==}
 
+  h3@2.0.1-rc.21:
+    resolution: {integrity: sha512-lDeqAgCQXWT7C+5Zs3ler2phZPeX5yTk9KqQuL8taSSngIhcPR0r83TZyYwTO/cLogm6a4+9slZcngrfdyZtrQ==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -5729,6 +5872,9 @@ packages:
   hookable@6.0.1:
     resolution: {integrity: sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==}
 
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -5753,6 +5899,9 @@ packages:
 
   httpxy@0.1.7:
     resolution: {integrity: sha512-pXNx8gnANKAndgga5ahefxc++tJvNL87CXoRwxn1cJE2ZkWEojF3tNfQIEhZX/vfpt+wzeAzpUI4qkediX1MLQ==}
+
+  httpxy@0.5.1:
+    resolution: {integrity: sha512-JPhqYiixe1A1I+MXDewWDZqeudBGU8Q9jCHYN8ML+779RQzLjTi78HBvWz4jMxUD6h2/vUL12g4q/mFM0OUw1A==}
 
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -6637,6 +6786,40 @@ packages:
     resolution: {integrity: sha512-Nc3loyVASW59W+8fLDZT1lncpG7llffyZ2o0UQLx/Fr20i7P8oP+lE7+TEcFvXj9IUWU6LjB9P3BH+iFGyp+mg==}
     engines: {node: ^14.16.0 || >=16.0.0}
 
+  nf3@0.3.16:
+    resolution: {integrity: sha512-Gs0xRPpUm2nDkqbi40NJ9g7qDIcjcJzgExiydnq6LAyqhI2jfno8wG3NKTL+IiJsx799UHOb1CnSd4Wg4SG4Pw==}
+
+  nitro@3.0.260429-beta:
+    resolution: {integrity: sha512-KweLVCUN5X9v9g+4yxAyRcz3FcOlnjmt9FyrAIWDxJETJmNT7I0JV0clgsONjo2nI0U5gwedXYA3RaNtF5XWzg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@vercel/queue': ^0.1.6
+      dotenv: '*'
+      giget: '*'
+      jiti: ^2.6.1
+      rollup: ^4.60.2
+      vite: ^7 || ^8
+      xml2js: ^0.6.2
+      zephyr-agent: ^0.2.0
+    peerDependenciesMeta:
+      '@vercel/queue':
+        optional: true
+      dotenv:
+        optional: true
+      giget:
+        optional: true
+      jiti:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      xml2js:
+        optional: true
+      zephyr-agent:
+        optional: true
+
   nitropack@2.13.1:
     resolution: {integrity: sha512-2dDj89C4wC2uzG7guF3CnyG+zwkZosPEp7FFBGHB3AJo11AywOolWhyQJFHDzve8COvGxJaqscye9wW2IrUsNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6780,6 +6963,9 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  ocache@0.1.4:
+    resolution: {integrity: sha512-e7geNdWjxSnvsSgvLuPvgKgu7ubM10ZmTPOgpr7mz2BXYtvjMKTiLhjFi/gWU8chkuP6hNkZBsa9LzOusyaqkQ==}
 
   ofetch@1.4.1:
     resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
@@ -7534,6 +7720,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rolldown@1.0.0-rc.18:
+    resolution: {integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup-plugin-dts@6.2.1:
     resolution: {integrity: sha512-sR3CxYUl7i2CHa0O7bA45mCrgADyAQ0tVtGSqi3yvH28M+eg1+g5d7kQ9hLvEz5dorK3XVsH5L2jwHLQf72DzA==}
     engines: {node: '>=16'}
@@ -7816,6 +8007,11 @@ packages:
 
   srvx@0.11.12:
     resolution: {integrity: sha512-AQfrGqntqVPXgP03pvBDN1KyevHC+KmYVqb8vVf4N+aomQqdhaZxjvoVp+AOm4u6x+GgNQY3MVzAUIn+TqwkOA==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
+  srvx@0.11.15:
+    resolution: {integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -8381,6 +8577,80 @@ packages:
       idb-keyval:
         optional: true
       ioredis:
+        optional: true
+      uploadthing:
+        optional: true
+
+  unstorage@2.0.0-alpha.7:
+    resolution: {integrity: sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.11.0
+      '@azure/cosmos': ^4.9.1
+      '@azure/data-tables': ^13.3.2
+      '@azure/identity': ^4.13.0
+      '@azure/keyvault-secrets': ^4.10.0
+      '@azure/storage-blob': ^12.31.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.13.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.36.2
+      '@vercel/blob': '>=0.27.3'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1.0.1
+      aws4fetch: ^1.0.20
+      chokidar: ^4 || ^5
+      db0: '>=0.3.4'
+      idb-keyval: ^6.2.2
+      ioredis: ^5.9.3
+      lru-cache: ^11.2.6
+      mongodb: ^6 || ^7
+      ofetch: '*'
+      uploadthing: ^7.7.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      chokidar:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      lru-cache:
+        optional: true
+      mongodb:
+        optional: true
+      ofetch:
         optional: true
       uploadthing:
         optional: true
@@ -9329,17 +9599,6 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@dxup/nuxt@0.4.0(magicast@0.3.5)(typescript@5.9.3)':
-    dependencies:
-      '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
-      chokidar: 5.0.0
-      pathe: 2.0.3
-      tinyglobby: 0.2.15
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - magicast
-
   '@dxup/nuxt@0.4.0(magicast@0.5.2)(typescript@5.9.3)':
     dependencies:
       '@dxup/unimport': 0.1.2
@@ -9353,9 +9612,20 @@ snapshots:
 
   '@dxup/unimport@0.1.2': {}
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -9365,6 +9635,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -9871,7 +10146,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -10064,8 +10339,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.10':
     dependencies:
-      '@emnapi/core': 1.8.1
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.9.0
     optional: true
 
@@ -10073,6 +10348,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.8.1
       '@emnapi/runtime': 1.8.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -10203,15 +10485,15 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/content@3.12.0(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(better-sqlite3@12.8.0)(magicast@0.3.5)(valibot@1.1.0(typescript@5.8.3))':
+  '@nuxt/content@3.12.0(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(better-sqlite3@12.8.0)(magicast@0.5.2)(valibot@1.1.0(typescript@5.8.3))':
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
-      '@nuxtjs/mdc': 0.20.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@nuxtjs/mdc': 0.20.2(magicast@0.5.2)
       '@shikijs/langs': 3.23.0
       '@sqlite.org/sqlite-wasm': 3.50.4-build1
       '@standard-schema/spec': 1.1.0
       '@webcontainer/env': 1.1.1
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       chokidar: 5.0.0
       consola: 3.4.2
       db0: 0.3.4(better-sqlite3@12.8.0)
@@ -10232,7 +10514,7 @@ snapshots:
       micromatch: 4.0.8
       minimark: 0.2.0
       minimatch: 10.2.4
-      nuxt-component-meta: 0.17.2(magicast@0.3.5)
+      nuxt-component-meta: 0.17.2(magicast@0.5.2)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -10275,17 +10557,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/devtools-kit@3.1.1(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))':
+  '@nuxt/devtools-kit@3.1.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))':
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
-      execa: 8.0.1
-      vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - magicast
-
-  '@nuxt/devtools-kit@3.2.3(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))':
-    dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       execa: 8.0.1
       vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -10442,7 +10716,7 @@ snapshots:
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
       vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.3.5))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
       vite-plugin-vue-tracer: 1.3.0(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       which: 5.0.0
       ws: 8.19.0
@@ -10521,14 +10795,14 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@nuxt/fonts@0.14.0(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))':
+  '@nuxt/fonts@0.14.0(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))':
     dependencies:
-      '@nuxt/devtools-kit': 3.2.3(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/devtools-kit': 3.2.3(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.4
       fontless: 0.2.1(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
-      h3: 1.15.5
+      h3: 1.15.6
       magic-regexp: 0.10.0
       ofetch: 1.5.1
       pathe: 2.0.3
@@ -10561,14 +10835,14 @@ snapshots:
       - uploadthing
       - vite
 
-  '@nuxt/icon@2.2.1(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))':
+  '@nuxt/icon@2.2.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@iconify/collections': 1.0.642
       '@iconify/types': 2.0.0
       '@iconify/utils': 3.1.0
       '@iconify/vue': 5.0.0(vue@3.5.30(typescript@5.9.3))
-      '@nuxt/devtools-kit': 3.1.1(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       consola: 3.4.2
       local-pkg: 1.1.2
       mlly: 1.8.1
@@ -10582,9 +10856,9 @@ snapshots:
       - vite
       - vue
 
-  '@nuxt/image@2.0.0(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.3.5)':
+  '@nuxt/image@2.0.0(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.5.2)':
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.4
       h3: 1.15.5
@@ -10621,6 +10895,33 @@ snapshots:
   '@nuxt/kit@3.17.5(magicast@0.3.5)':
     dependencies:
       c12: 3.0.4(magicast@0.3.5)
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.0.5
+      ignore: 7.0.5
+      jiti: 2.4.2
+      klona: 2.0.6
+      knitwork: 1.2.0
+      mlly: 1.7.4
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.1.0
+      scule: 1.3.0
+      semver: 7.7.2
+      std-env: 3.10.0
+      tinyglobby: 0.2.14
+      ufo: 1.6.1
+      unctx: 2.4.1
+      unimport: 5.0.1
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@nuxt/kit@3.17.5(magicast@0.5.2)':
+    dependencies:
+      c12: 3.0.4(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -10718,139 +11019,7 @@ snapshots:
       - vue
       - vue-tsc
 
-  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.3.5)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(typescript@5.9.3)':
-    dependencies:
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
-      '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
-      '@vue/shared': 3.5.30
-      consola: 3.4.2
-      defu: 6.1.4
-      destr: 2.0.5
-      devalue: 5.6.4
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      h3: 1.15.6
-      impound: 1.1.5
-      klona: 2.0.6
-      mocked-exports: 0.1.1
-      nitropack: 2.13.1(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
-      nypm: 0.6.5
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      rou3: 0.8.1
-      std-env: 4.0.0
-      ufo: 1.6.3
-      unctx: 2.5.0
-      unstorage: 1.17.4(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)
-      vue: 3.5.30(typescript@5.9.3)
-      vue-bundle-renderer: 2.2.0
-      vue-devtools-stub: 0.1.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - better-sqlite3
-      - db0
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - ioredis
-      - magicast
-      - mysql2
-      - rolldown
-      - sqlite3
-      - supports-color
-      - typescript
-      - uploadthing
-      - xml2js
-
-  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.3.5)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2))(typescript@5.8.3)':
-    dependencies:
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
-      '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.8.3))
-      '@vue/shared': 3.5.30
-      consola: 3.4.2
-      defu: 6.1.4
-      destr: 2.0.5
-      devalue: 5.6.4
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      h3: 1.15.6
-      impound: 1.1.5
-      klona: 2.0.6
-      mocked-exports: 0.1.1
-      nitropack: 2.13.1(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2)
-      nypm: 0.6.5
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      rou3: 0.8.1
-      std-env: 4.0.0
-      ufo: 1.6.3
-      unctx: 2.5.0
-      unstorage: 1.17.4(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)
-      vue: 3.5.30(typescript@5.8.3)
-      vue-bundle-renderer: 2.2.0
-      vue-devtools-stub: 0.1.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - better-sqlite3
-      - db0
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - ioredis
-      - magicast
-      - mysql2
-      - rolldown
-      - sqlite3
-      - supports-color
-      - typescript
-      - uploadthing
-      - xml2js
-
-  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(rolldown@1.0.0-rc.18)(typescript@5.9.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -10868,8 +11037,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.1(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+      nitropack: 2.13.1(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(rolldown@1.0.0-rc.18)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -10880,6 +11049,138 @@ snapshots:
       unctx: 2.5.0
       unstorage: 1.17.4(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)
       vue: 3.5.30(typescript@5.9.3)
+      vue-bundle-renderer: 2.2.0
+      vue-devtools-stub: 0.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - better-sqlite3
+      - db0
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - ioredis
+      - magicast
+      - mysql2
+      - rolldown
+      - sqlite3
+      - supports-color
+      - typescript
+      - uploadthing
+      - xml2js
+
+  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(rolldown@1.0.0-rc.18)(typescript@5.9.3)':
+    dependencies:
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
+      '@vue/shared': 3.5.30
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      devalue: 5.6.4
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      h3: 1.15.6
+      impound: 1.1.5
+      klona: 2.0.6
+      mocked-exports: 0.1.1
+      nitropack: 2.13.1(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(rolldown@1.0.0-rc.18)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+      nypm: 0.6.5
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      rou3: 0.8.1
+      std-env: 4.0.0
+      ufo: 1.6.3
+      unctx: 2.5.0
+      unstorage: 1.17.4(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)
+      vue: 3.5.30(typescript@5.9.3)
+      vue-bundle-renderer: 2.2.0
+      vue-devtools-stub: 0.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - better-sqlite3
+      - db0
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - ioredis
+      - magicast
+      - mysql2
+      - rolldown
+      - sqlite3
+      - supports-color
+      - typescript
+      - uploadthing
+      - xml2js
+
+  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(db0@0.3.4(better-sqlite3@12.8.0))(magicast@0.3.5)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2))(rolldown@1.0.0-rc.18)(typescript@5.8.3)':
+    dependencies:
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.8.3))
+      '@vue/shared': 3.5.30
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      devalue: 5.6.4
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      h3: 1.15.6
+      impound: 1.1.5
+      klona: 2.0.6
+      mocked-exports: 0.1.1
+      nitropack: 2.13.1(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(rolldown@1.0.0-rc.18)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2)
+      nypm: 0.6.5
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      rou3: 0.8.1
+      std-env: 4.0.0
+      ufo: 1.6.3
+      unctx: 2.5.0
+      unstorage: 1.17.4(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)
+      vue: 3.5.30(typescript@5.8.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
     transitivePeerDependencies:
@@ -10941,6 +11242,15 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
+  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))':
+    dependencies:
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      citty: 0.2.1
+      consola: 3.4.2
+      ofetch: 2.0.0-alpha.3
+      rc9: 3.0.0
+      std-env: 3.10.0
+
   '@nuxt/test-utils@3.19.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(magicast@0.3.5)(playwright-core@1.58.2)(terser@5.40.0)(typescript@5.8.3)(vitest@3.2.1(@types/debug@4.1.12)(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 3.17.5(magicast@0.3.5)
@@ -10987,17 +11297,17 @@ snapshots:
       - typescript
       - yaml
 
-  '@nuxt/ui@4.5.1(@netlify/blobs@9.1.2)(@nuxt/content@3.12.0(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(better-sqlite3@12.8.0)(magicast@0.3.5)(valibot@1.1.0(typescript@5.8.3)))(@tiptap/extensions@3.20.2(@tiptap/core@3.20.2(@tiptap/pm@3.20.2))(@tiptap/pm@3.20.2))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4(better-sqlite3@12.8.0))(embla-carousel@8.6.0)(ioredis@5.9.2)(jwt-decode@4.0.0)(magicast@0.3.5)(tailwindcss@4.2.1)(typescript@5.9.3)(valibot@1.1.0(typescript@5.8.3))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))(yjs@13.6.29)(zod@4.3.6)':
+  '@nuxt/ui@4.5.1(@netlify/blobs@9.1.2)(@nuxt/content@3.12.0(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(better-sqlite3@12.8.0)(magicast@0.5.2)(valibot@1.1.0(typescript@5.8.3)))(@tiptap/extensions@3.20.2(@tiptap/core@3.20.2(@tiptap/pm@3.20.2))(@tiptap/pm@3.20.2))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4(better-sqlite3@12.8.0))(embla-carousel@8.6.0)(ioredis@5.9.2)(jwt-decode@4.0.0)(magicast@0.5.2)(tailwindcss@4.2.1)(typescript@5.9.3)(valibot@1.1.0(typescript@5.8.3))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))(yjs@13.6.29)(zod@4.3.6)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@iconify/vue': 5.0.0(vue@3.5.30(typescript@5.9.3))
       '@internationalized/date': 3.12.0
       '@internationalized/number': 3.6.5
-      '@nuxt/fonts': 0.14.0(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
-      '@nuxt/icon': 2.2.1(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/fonts': 0.14.0(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
+      '@nuxt/icon': 2.2.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@nuxt/schema': 4.4.2
-      '@nuxtjs/color-mode': 3.5.2(magicast@0.3.5)
+      '@nuxtjs/color-mode': 3.5.2(magicast@0.5.2)
       '@standard-schema/spec': 1.1.0
       '@tailwindcss/postcss': 4.2.1
       '@tailwindcss/vite': 4.2.1(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
@@ -11051,12 +11361,12 @@ snapshots:
       typescript: 5.9.3
       ufo: 1.6.3
       unplugin: 3.0.0
-      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.2(magicast@0.3.5))(@vueuse/core@14.2.1(vue@3.5.30(typescript@5.9.3)))
-      unplugin-vue-components: 31.0.0(@nuxt/kit@4.4.2(magicast@0.3.5))(vue@3.5.30(typescript@5.9.3))
+      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.2(magicast@0.5.2))(@vueuse/core@14.2.1(vue@3.5.30(typescript@5.9.3)))
+      unplugin-vue-components: 31.0.0(@nuxt/kit@4.4.2(magicast@0.5.2))(vue@3.5.30(typescript@5.9.3))
       vaul-vue: 0.4.1(reka-ui@2.8.2(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       vue-component-type-helpers: 3.2.5
     optionalDependencies:
-      '@nuxt/content': 3.12.0(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(better-sqlite3@12.8.0)(magicast@0.3.5)(valibot@1.1.0(typescript@5.8.3))
+      '@nuxt/content': 3.12.0(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(better-sqlite3@12.8.0)(magicast@0.5.2)(valibot@1.1.0(typescript@5.8.3))
       valibot: 1.1.0(typescript@5.8.3)
       vue-router: 4.6.4(vue@3.5.30(typescript@5.9.3))
       zod: 4.3.6
@@ -11102,67 +11412,7 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vue-tsc@2.2.10(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)':
-    dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.56.0)
-      '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      autoprefixer: 10.4.27(postcss@8.5.8)
-      consola: 3.4.2
-      cssnano: 7.1.3(postcss@8.5.8)
-      defu: 6.1.4
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      get-port-please: 3.2.0
-      jiti: 2.6.1
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.1
-      mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
-      nypm: 0.6.5
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      postcss: 8.5.8
-      seroval: 1.5.1
-      std-env: 4.0.0
-      ufo: 1.6.3
-      unenv: 2.0.0-rc.24
-      vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2)
-      vite-node: 5.3.0(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2)
-      vite-plugin-checker: 0.12.0(eslint@9.28.0(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))
-      vue: 3.5.30(typescript@5.9.3)
-      vue-bundle-renderer: 2.2.0
-    optionalDependencies:
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      rollup-plugin-visualizer: 6.0.5(rollup@4.56.0)
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - oxlint
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - vls
-      - vti
-      - vue-tsc
-      - yaml
-
-  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2))(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(vue@3.5.30(typescript@5.8.3))(yaml@2.8.2)':
+  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(vue@3.5.30(typescript@5.8.3))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.3(rollup@4.41.1)
@@ -11180,7 +11430,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.1
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -11196,7 +11446,8 @@ snapshots:
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      rollup-plugin-visualizer: 6.0.5(rollup@4.41.1)
+      rolldown: 1.0.0-rc.18
+      rollup-plugin-visualizer: 6.0.5(rolldown@1.0.0-rc.18)(rollup@4.41.1)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -11222,7 +11473,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vue-tsc@2.2.10(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)':
+  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vue-tsc@2.2.10(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.56.0)
@@ -11240,7 +11491,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.1
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -11256,7 +11507,8 @@ snapshots:
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      rollup-plugin-visualizer: 6.0.5(rollup@4.56.0)
+      rolldown: 1.0.0-rc.18
+      rollup-plugin-visualizer: 6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -11282,16 +11534,77 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxtjs/color-mode@3.5.2(magicast@0.3.5)':
+  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vue-tsc@2.2.10(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
-      '@nuxt/kit': 3.17.5(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.56.0)
+      '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
+      autoprefixer: 10.4.27(postcss@8.5.8)
+      consola: 3.4.2
+      cssnano: 7.1.3(postcss@8.5.8)
+      defu: 6.1.4
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      get-port-please: 3.2.0
+      jiti: 2.6.1
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.1
+      mocked-exports: 0.1.1
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+      nypm: 0.6.5
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      postcss: 8.5.8
+      seroval: 1.5.1
+      std-env: 4.0.0
+      ufo: 1.6.3
+      unenv: 2.0.0-rc.24
+      vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2)
+      vite-node: 5.3.0(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2)
+      vite-plugin-checker: 0.12.0(eslint@9.28.0(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.9.3)
+      vue-bundle-renderer: 2.2.0
+    optionalDependencies:
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      rolldown: 1.0.0-rc.18
+      rollup-plugin-visualizer: 6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0)
+    transitivePeerDependencies:
+      - '@biomejs/biome'
+      - '@types/node'
+      - eslint
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - optionator
+      - oxlint
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - vls
+      - vti
+      - vue-tsc
+      - yaml
+
+  '@nuxtjs/color-mode@3.5.2(magicast@0.5.2)':
+    dependencies:
+      '@nuxt/kit': 3.17.5(magicast@0.5.2)
       pathe: 1.1.2
       pkg-types: 1.3.1
       semver: 7.7.4
     transitivePeerDependencies:
       - magicast
 
-  '@nuxtjs/i18n@10.2.3(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.30)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(magicast@0.3.5)(rollup@4.56.0)(vue@3.5.30(typescript@5.9.3))':
+  '@nuxtjs/i18n@10.2.3(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.30)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(magicast@0.5.2)(rollup@4.56.0)(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@intlify/core': 11.3.0
       '@intlify/h3': 0.7.4
@@ -11299,7 +11612,7 @@ snapshots:
       '@intlify/unplugin-vue-i18n': 11.0.7(@vue/compiler-dom@3.5.30)(eslint@9.28.0(jiti@2.6.1))(rollup@4.56.0)(typescript@5.9.3)(vue-i18n@11.3.0(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       '@intlify/utils': 0.13.0
       '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.56.0)
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-yaml': 4.1.2(rollup@4.56.0)
       '@vue/compiler-sfc': 3.5.27
       defu: 6.1.4
@@ -11349,10 +11662,10 @@ snapshots:
       - uploadthing
       - vue
 
-  '@nuxtjs/mcp-toolkit@0.7.0(@cfworker/json-schema@4.1.1)(magicast@0.3.5)(zod@4.3.6)':
+  '@nuxtjs/mcp-toolkit@0.7.0(@cfworker/json-schema@4.1.1)(magicast@0.5.2)(zod@4.3.6)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       defu: 6.1.4
       ms: 2.1.3
       pathe: 2.0.3
@@ -11365,9 +11678,9 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxtjs/mdc@0.20.2(magicast@0.3.5)':
+  '@nuxtjs/mdc@0.20.2(magicast@0.5.2)':
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@shikijs/core': 3.23.0
       '@shikijs/langs': 3.23.0
       '@shikijs/themes': 3.23.0
@@ -11414,15 +11727,15 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxtjs/robots@5.7.1(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))(zod@4.3.6)':
+  '@nuxtjs/robots@5.7.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))(zod@4.3.6)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
-      '@nuxt/devtools-kit': 3.2.3(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/devtools-kit': 3.2.3(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.4
       h3: 1.15.5
-      nuxt-site-config: 3.2.21(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
+      nuxt-site-config: 3.2.21(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       pathe: 2.0.3
       pkg-types: 2.3.0
       sirv: 3.0.2
@@ -11609,6 +11922,8 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.117.0': {}
+
+  '@oxc-project/types@0.128.0': {}
 
   '@oxc-project/types@0.95.0': {}
 
@@ -11861,6 +12176,57 @@ snapshots:
       '@resvg/resvg-js-win32-x64-msvc': 2.6.2
 
   '@resvg/resvg-wasm@2.6.2': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.18': {}
 
   '@rolldown/pluginutils@1.0.0-rc.2': {}
 
@@ -13773,6 +14139,23 @@ snapshots:
     optionalDependencies:
       magicast: 0.3.5
 
+  c12@3.0.4(magicast@0.5.2):
+    dependencies:
+      chokidar: 4.0.3
+      confbox: 0.2.2
+      defu: 6.1.4
+      dotenv: 16.5.0
+      exsolve: 1.0.5
+      giget: 2.0.0
+      jiti: 2.4.2
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 2.3.0
+      rc9: 2.1.2
+    optionalDependencies:
+      magicast: 0.5.2
+
   c12@3.3.3(magicast@0.3.5):
     dependencies:
       chokidar: 5.0.0
@@ -14045,6 +14428,10 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
+  crossws@0.4.5(srvx@0.11.15):
+    optionalDependencies:
+      srvx: 0.11.15
+
   css-background-parser@0.1.0: {}
 
   css-box-shadow@1.0.0-3: {}
@@ -14227,7 +14614,7 @@ snapshots:
 
   diff@8.0.3: {}
 
-  docus@5.8.1(lm5hnwzjdjozjmwueejgquhx54):
+  docus@5.8.1(f632owwsyx6xoqwovimq3l4zhu):
     dependencies:
       '@ai-sdk/gateway': 3.0.66(zod@4.3.6)
       '@ai-sdk/mcp': 1.0.25(zod@4.3.6)
@@ -14235,14 +14622,14 @@ snapshots:
       '@iconify-json/lucide': 1.2.98
       '@iconify-json/simple-icons': 1.2.74
       '@iconify-json/vscode-icons': 1.2.45
-      '@nuxt/content': 3.12.0(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(better-sqlite3@12.8.0)(magicast@0.3.5)(valibot@1.1.0(typescript@5.8.3))
-      '@nuxt/image': 2.0.0(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.3.5)
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
-      '@nuxt/ui': 4.5.1(@netlify/blobs@9.1.2)(@nuxt/content@3.12.0(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(better-sqlite3@12.8.0)(magicast@0.3.5)(valibot@1.1.0(typescript@5.8.3)))(@tiptap/extensions@3.20.2(@tiptap/core@3.20.2(@tiptap/pm@3.20.2))(@tiptap/pm@3.20.2))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4(better-sqlite3@12.8.0))(embla-carousel@8.6.0)(ioredis@5.9.2)(jwt-decode@4.0.0)(magicast@0.3.5)(tailwindcss@4.2.1)(typescript@5.9.3)(valibot@1.1.0(typescript@5.8.3))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))(yjs@13.6.29)(zod@4.3.6)
-      '@nuxtjs/i18n': 10.2.3(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.30)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(magicast@0.3.5)(rollup@4.56.0)(vue@3.5.30(typescript@5.9.3))
-      '@nuxtjs/mcp-toolkit': 0.7.0(@cfworker/json-schema@4.1.1)(magicast@0.3.5)(zod@4.3.6)
-      '@nuxtjs/mdc': 0.20.2(magicast@0.3.5)
-      '@nuxtjs/robots': 5.7.1(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))(zod@4.3.6)
+      '@nuxt/content': 3.12.0(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(better-sqlite3@12.8.0)(magicast@0.5.2)(valibot@1.1.0(typescript@5.8.3))
+      '@nuxt/image': 2.0.0(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.5.2)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@nuxt/ui': 4.5.1(@netlify/blobs@9.1.2)(@nuxt/content@3.12.0(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(better-sqlite3@12.8.0)(magicast@0.5.2)(valibot@1.1.0(typescript@5.8.3)))(@tiptap/extensions@3.20.2(@tiptap/core@3.20.2(@tiptap/pm@3.20.2))(@tiptap/pm@3.20.2))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4(better-sqlite3@12.8.0))(embla-carousel@8.6.0)(ioredis@5.9.2)(jwt-decode@4.0.0)(magicast@0.5.2)(tailwindcss@4.2.1)(typescript@5.9.3)(valibot@1.1.0(typescript@5.8.3))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))(yjs@13.6.29)(zod@4.3.6)
+      '@nuxtjs/i18n': 10.2.3(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.30)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(magicast@0.5.2)(rollup@4.56.0)(vue@3.5.30(typescript@5.9.3))
+      '@nuxtjs/mcp-toolkit': 0.7.0(@cfworker/json-schema@4.1.1)(magicast@0.5.2)(zod@4.3.6)
+      '@nuxtjs/mdc': 0.20.2(magicast@0.5.2)
+      '@nuxtjs/robots': 5.7.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))(zod@4.3.6)
       '@shikijs/core': 3.23.0
       '@shikijs/engine-javascript': 3.23.0
       '@shikijs/langs': 3.23.0
@@ -14254,9 +14641,9 @@ snapshots:
       exsolve: 1.0.8
       git-url-parse: 16.1.0
       motion-v: 1.10.3(@vueuse/core@14.2.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
-      nuxt-llms: 0.2.0(magicast@0.3.5)
-      nuxt-og-image: 5.1.13(@unhead/vue@2.1.12(vue@3.5.30(typescript@5.9.3)))(magicast@0.3.5)(unstorage@1.17.4(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2)
+      nuxt-llms: 0.2.0(magicast@0.5.2)
+      nuxt-og-image: 5.1.13(@unhead/vue@2.1.12(vue@3.5.30(typescript@5.9.3)))(magicast@0.5.2)(unstorage@2.0.0-alpha.7(@netlify/blobs@9.1.2)(chokidar@5.0.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(ofetch@1.5.1))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       pkg-types: 2.3.0
       scule: 1.3.0
       shiki-stream: 0.1.4(vue@3.5.30(typescript@5.9.3))
@@ -14463,6 +14850,13 @@ snapshots:
 
   env-paths@3.0.0:
     optional: true
+
+  env-runner@0.1.7:
+    dependencies:
+      crossws: 0.4.5(srvx@0.11.15)
+      exsolve: 1.0.8
+      httpxy: 0.5.1
+      srvx: 0.11.15
 
   environment@1.1.0: {}
 
@@ -15342,6 +15736,13 @@ snapshots:
       ufo: 1.6.3
       uncrypto: 0.1.3
 
+  h3@2.0.1-rc.21(crossws@0.4.5(srvx@0.11.15)):
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.15
+    optionalDependencies:
+      crossws: 0.4.5(srvx@0.11.15)
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -15512,6 +15913,8 @@ snapshots:
 
   hookable@6.0.1: {}
 
+  hookable@6.1.1: {}
+
   html-void-elements@3.0.0: {}
 
   html-whitespace-sensitive-tag-names@3.0.1: {}
@@ -15542,6 +15945,8 @@ snapshots:
       - supports-color
 
   httpxy@0.1.7: {}
+
+  httpxy@0.5.1: {}
 
   human-signals@5.0.0: {}
 
@@ -15612,7 +16017,7 @@ snapshots:
       defu: 6.1.4
       destr: 2.0.5
       etag: 1.8.1
-      h3: 1.15.5
+      h3: 1.15.6
       image-meta: 0.2.2
       listhen: 1.9.0
       ofetch: 1.5.1
@@ -16596,7 +17001,62 @@ snapshots:
       qs: 6.15.0
     optional: true
 
-  nitropack@2.13.1(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0):
+  nf3@0.3.16: {}
+
+  nitro@3.0.260429-beta(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@17.2.3)(giget@3.1.2)(jiti@2.6.1)(rollup@4.41.1)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2)):
+    dependencies:
+      consola: 3.4.2
+      crossws: 0.4.5(srvx@0.11.15)
+      db0: 0.3.4(better-sqlite3@12.8.0)
+      env-runner: 0.1.7
+      h3: 2.0.1-rc.21(crossws@0.4.5(srvx@0.11.15))
+      hookable: 6.1.1
+      nf3: 0.3.16
+      ocache: 0.1.4
+      ofetch: 2.0.0-alpha.3
+      ohash: 2.0.11
+      rolldown: 1.0.0-rc.18
+      srvx: 0.11.15
+      unenv: 2.0.0-rc.24
+      unstorage: 2.0.0-alpha.7(@netlify/blobs@9.1.2)(chokidar@5.0.0)(db0@0.3.4(better-sqlite3@12.8.0))(ofetch@2.0.0-alpha.3)
+    optionalDependencies:
+      dotenv: 17.2.3
+      giget: 3.1.2
+      jiti: 2.6.1
+      rollup: 4.41.1
+      vite: 6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - drizzle-orm
+      - idb-keyval
+      - ioredis
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - sqlite3
+      - uploadthing
+
+  nitropack@2.13.1(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(rolldown@1.0.0-rc.18):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.56.0)
@@ -16649,7 +17109,7 @@ snapshots:
       pretty-bytes: 7.1.0
       radix3: 1.1.2
       rollup: 4.56.0
-      rollup-plugin-visualizer: 6.0.5(rollup@4.56.0)
+      rollup-plugin-visualizer: 6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0)
       scule: 1.3.0
       semver: 7.7.4
       serve-placeholder: 2.0.2
@@ -16756,9 +17216,9 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt-component-meta@0.17.2(magicast@0.3.5):
+  nuxt-component-meta@0.17.2(magicast@0.5.2):
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       citty: 0.1.6
       mlly: 1.8.1
       ohash: 2.0.11
@@ -16771,16 +17231,16 @@ snapshots:
 
   nuxt-define@1.0.0: {}
 
-  nuxt-llms@0.2.0(magicast@0.3.5):
+  nuxt-llms@0.2.0(magicast@0.5.2):
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@5.1.13(@unhead/vue@2.1.12(vue@3.5.30(typescript@5.9.3)))(magicast@0.3.5)(unstorage@1.17.4(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)):
+  nuxt-og-image@5.1.13(@unhead/vue@2.1.12(vue@3.5.30(typescript@5.9.3)))(magicast@0.5.2)(unstorage@2.0.0-alpha.7(@netlify/blobs@9.1.2)(chokidar@5.0.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(ofetch@1.5.1))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
-      '@nuxt/devtools-kit': 3.1.1(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@resvg/resvg-js': 2.6.2
       '@resvg/resvg-wasm': 2.6.2
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
@@ -16793,7 +17253,7 @@ snapshots:
       image-size: 2.0.2
       magic-string: 0.30.21
       mocked-exports: 0.1.1
-      nuxt-site-config: 3.2.21(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
+      nuxt-site-config: 3.2.21(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       nypm: 0.6.4
       ofetch: 1.5.1
       ohash: 2.0.11
@@ -16808,7 +17268,7 @@ snapshots:
       strip-literal: 3.1.0
       ufo: 1.6.3
       unplugin: 2.3.11
-      unstorage: 1.17.4(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)
+      unstorage: 2.0.0-alpha.7(@netlify/blobs@9.1.2)(chokidar@5.0.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(ofetch@1.5.1)
       unwasm: 0.5.3
       yoga-wasm-web: 0.3.3
     transitivePeerDependencies:
@@ -16817,9 +17277,9 @@ snapshots:
       - vite
       - vue
 
-  nuxt-site-config-kit@3.2.21(magicast@0.3.5)(vue@3.5.30(typescript@5.9.3)):
+  nuxt-site-config-kit@3.2.21(magicast@0.5.2)(vue@3.5.30(typescript@5.9.3)):
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       pkg-types: 2.3.0
       site-config-stack: 3.2.21(vue@3.5.30(typescript@5.9.3))
       std-env: 3.10.0
@@ -16828,12 +17288,12 @@ snapshots:
       - magicast
       - vue
 
-  nuxt-site-config@3.2.21(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)):
+  nuxt-site-config@3.2.21(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
-      '@nuxt/devtools-kit': 3.2.3(magicast@0.3.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
-      h3: 1.15.5
-      nuxt-site-config-kit: 3.2.21(magicast@0.3.5)(vue@3.5.30(typescript@5.9.3))
+      '@nuxt/devtools-kit': 3.2.3(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      h3: 1.15.6
+      nuxt-site-config-kit: 3.2.21(magicast@0.5.2)(vue@3.5.30(typescript@5.9.3))
       pathe: 2.0.3
       pkg-types: 2.3.0
       sirv: 3.0.2
@@ -16844,19 +17304,19 @@ snapshots:
       - vite
       - vue
 
-  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2):
+  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2):
     dependencies:
-      '@dxup/nuxt': 0.4.0(magicast@0.3.5)(typescript@5.9.3)
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.3.5)
+      '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.3(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
-      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.3.5)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(typescript@5.9.3)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(rolldown@1.0.0-rc.18)(typescript@5.9.3)
       '@nuxt/schema': 4.4.2
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.3.5))
-      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vue-tsc@2.2.10(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))
+      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.27)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vue-tsc@2.2.10(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       chokidar: 5.0.0
       compatx: 0.2.0
       consola: 3.4.2
@@ -16971,143 +17431,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2):
-    dependencies:
-      '@dxup/nuxt': 0.4.0(magicast@0.3.5)(typescript@5.8.3)
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.3.5)
-      '@nuxt/devtools': 3.2.3(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3))
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
-      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.3.5)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2))(typescript@5.8.3)
-      '@nuxt/schema': 4.4.2
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.3.5))
-      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2))(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(vue@3.5.30(typescript@5.8.3))(yaml@2.8.2)
-      '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.8.3))
-      '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.3.5)
-      chokidar: 5.0.0
-      compatx: 0.2.0
-      consola: 3.4.2
-      cookie-es: 2.0.0
-      defu: 6.1.4
-      devalue: 5.6.4
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      hookable: 6.0.1
-      ignore: 7.0.5
-      impound: 1.1.5
-      jiti: 2.6.1
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.1
-      nanotar: 0.3.0
-      nypm: 0.6.5
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 6.0.2
-      oxc-minify: 0.117.0
-      oxc-parser: 0.117.0
-      oxc-transform: 0.117.0
-      oxc-walker: 0.7.0(oxc-parser@0.117.0)
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      picomatch: 4.0.3
-      pkg-types: 2.3.0
-      rou3: 0.8.1
-      scule: 1.3.0
-      semver: 7.7.4
-      std-env: 4.0.0
-      tinyglobby: 0.2.15
-      ufo: 1.6.3
-      ultrahtml: 1.6.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unimport: 6.0.1
-      unplugin: 3.0.0
-      unrouting: 0.1.7
-      untyped: 2.0.0
-      vue: 3.5.30(typescript@5.8.3)
-      vue-router: 5.0.3(@vue/compiler-sfc@3.5.30)(vue@3.5.30(typescript@5.8.3))
-    optionalDependencies:
-      '@parcel/watcher': 2.5.1
-      '@types/node': 25.6.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@babel/plugin-proposal-decorators'
-      - '@babel/plugin-syntax-jsx'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@rollup/plugin-babel'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - '@vue/compiler-sfc'
-      - aws4fetch
-      - better-sqlite3
-      - bufferutil
-      - cac
-      - commander
-      - db0
-      - drizzle-orm
-      - encoding
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - oxlint
-      - pinia
-      - rolldown
-      - rollup
-      - rollup-plugin-visualizer
-      - sass
-      - sass-embedded
-      - sqlite3
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vls
-      - vti
-      - vue-tsc
-      - xml2js
-      - yaml
-
-  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2):
+  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.3(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(typescript@5.9.3)
+      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(rolldown@1.0.0-rc.18)(typescript@5.9.3)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.3.5))
-      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rollup-plugin-visualizer@6.0.5(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vue-tsc@2.2.10(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)
+      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(ioredis@5.9.2)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0))(rollup@4.56.0)(terser@5.40.0)(typescript@5.9.3)(vue-tsc@2.2.10(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
       c12: 3.3.3(magicast@0.5.2)
@@ -17225,6 +17558,133 @@ snapshots:
       - xml2js
       - yaml
 
+  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2):
+    dependencies:
+      '@dxup/nuxt': 0.4.0(magicast@0.3.5)(typescript@5.8.3)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.3.5)
+      '@nuxt/devtools': 3.2.3(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.8.3))
+      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(better-sqlite3@12.8.0)(db0@0.3.4(better-sqlite3@12.8.0))(magicast@0.3.5)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2))(rolldown@1.0.0-rc.18)(typescript@5.8.3)
+      '@nuxt/schema': 4.4.2
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.3.5))
+      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0))(eslint@9.28.0(jiti@2.6.1))(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vite@6.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.18)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.41.1))(rollup@4.41.1)(terser@5.40.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(vue@3.5.30(typescript@5.8.3))(yaml@2.8.2)
+      '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.8.3))
+      '@vue/shared': 3.5.30
+      c12: 3.3.3(magicast@0.3.5)
+      chokidar: 5.0.0
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 2.0.0
+      defu: 6.1.4
+      devalue: 5.6.4
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      hookable: 6.0.1
+      ignore: 7.0.5
+      impound: 1.1.5
+      jiti: 2.6.1
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.1
+      nanotar: 0.3.0
+      nypm: 0.6.5
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 6.0.2
+      oxc-minify: 0.117.0
+      oxc-parser: 0.117.0
+      oxc-transform: 0.117.0
+      oxc-walker: 0.7.0(oxc-parser@0.117.0)
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      picomatch: 4.0.3
+      pkg-types: 2.3.0
+      rou3: 0.8.1
+      scule: 1.3.0
+      semver: 7.7.4
+      std-env: 4.0.0
+      tinyglobby: 0.2.15
+      ufo: 1.6.3
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unimport: 6.0.1
+      unplugin: 3.0.0
+      unrouting: 0.1.7
+      untyped: 2.0.0
+      vue: 3.5.30(typescript@5.8.3)
+      vue-router: 5.0.3(@vue/compiler-sfc@3.5.30)(vue@3.5.30(typescript@5.8.3))
+    optionalDependencies:
+      '@parcel/watcher': 2.5.1
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@babel/plugin-proposal-decorators'
+      - '@babel/plugin-syntax-jsx'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rollup/plugin-babel'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - better-sqlite3
+      - bufferutil
+      - cac
+      - commander
+      - db0
+      - drizzle-orm
+      - encoding
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - oxlint
+      - pinia
+      - rolldown
+      - rollup
+      - rollup-plugin-visualizer
+      - sass
+      - sass-embedded
+      - sqlite3
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vls
+      - vti
+      - vue-tsc
+      - xml2js
+      - yaml
+
   nypm@0.6.0:
     dependencies:
       citty: 0.1.6
@@ -17250,6 +17710,10 @@ snapshots:
   object-inspect@1.13.4: {}
 
   obug@2.1.1: {}
+
+  ocache@0.1.4:
+    dependencies:
+      ohash: 2.0.11
 
   ofetch@1.4.1:
     dependencies:
@@ -18206,6 +18670,27 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rolldown@1.0.0-rc.18:
+    dependencies:
+      '@oxc-project/types': 0.128.0
+      '@rolldown/pluginutils': 1.0.0-rc.18
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.18
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.18
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.18
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.18
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.18
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.18
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.18
+
   rollup-plugin-dts@6.2.1(rollup@4.41.1)(typescript@5.8.3):
     dependencies:
       magic-string: 0.30.21
@@ -18222,23 +18707,25 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.28.6
 
-  rollup-plugin-visualizer@6.0.5(rollup@4.41.1):
+  rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.41.1):
     dependencies:
       open: 8.4.2
       picomatch: 4.0.3
       source-map: 0.7.6
       yargs: 17.7.2
     optionalDependencies:
+      rolldown: 1.0.0-rc.18
       rollup: 4.41.1
     optional: true
 
-  rollup-plugin-visualizer@6.0.5(rollup@4.56.0):
+  rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.18)(rollup@4.56.0):
     dependencies:
       open: 8.4.2
       picomatch: 4.0.3
       source-map: 0.7.6
       yargs: 17.7.2
     optionalDependencies:
+      rolldown: 1.0.0-rc.18
       rollup: 4.56.0
 
   rollup@4.41.1:
@@ -18635,6 +19122,8 @@ snapshots:
   speakingurl@14.0.1: {}
 
   srvx@0.11.12: {}
+
+  srvx@0.11.15: {}
 
   stable-hash@0.0.5: {}
 
@@ -19167,7 +19656,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-auto-import@21.0.0(@nuxt/kit@4.4.2(magicast@0.3.5))(@vueuse/core@14.2.1(vue@3.5.30(typescript@5.9.3))):
+  unplugin-auto-import@21.0.0(@nuxt/kit@4.4.2(magicast@0.5.2))(@vueuse/core@14.2.1(vue@3.5.30(typescript@5.9.3))):
     dependencies:
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -19176,7 +19665,7 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.3.1
     optionalDependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@vueuse/core': 14.2.1(vue@3.5.30(typescript@5.9.3))
 
   unplugin-utils@0.2.4:
@@ -19189,7 +19678,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.3
 
-  unplugin-vue-components@31.0.0(@nuxt/kit@4.4.2(magicast@0.3.5))(vue@3.5.30(typescript@5.9.3)):
+  unplugin-vue-components@31.0.0(@nuxt/kit@4.4.2(magicast@0.5.2))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       chokidar: 5.0.0
       local-pkg: 1.1.2
@@ -19202,7 +19691,7 @@ snapshots:
       unplugin-utils: 0.3.1
       vue: 3.5.30(typescript@5.9.3)
     optionalDependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
 
   unplugin-vue-router@0.16.2(@vue/compiler-sfc@3.5.27)(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
@@ -19280,7 +19769,7 @@ snapshots:
       anymatch: 3.1.3
       chokidar: 5.0.0
       destr: 2.0.5
-      h3: 1.15.5
+      h3: 1.15.6
       lru-cache: 11.2.4
       node-fetch-native: 1.6.7
       ofetch: 1.5.1
@@ -19289,6 +19778,21 @@ snapshots:
       '@netlify/blobs': 9.1.2
       db0: 0.3.4(better-sqlite3@12.8.0)
       ioredis: 5.9.2
+
+  unstorage@2.0.0-alpha.7(@netlify/blobs@9.1.2)(chokidar@5.0.0)(db0@0.3.4(better-sqlite3@12.8.0))(ioredis@5.9.2)(ofetch@1.5.1):
+    optionalDependencies:
+      '@netlify/blobs': 9.1.2
+      chokidar: 5.0.0
+      db0: 0.3.4(better-sqlite3@12.8.0)
+      ioredis: 5.9.2
+      ofetch: 1.5.1
+
+  unstorage@2.0.0-alpha.7(@netlify/blobs@9.1.2)(chokidar@5.0.0)(db0@0.3.4(better-sqlite3@12.8.0))(ofetch@2.0.0-alpha.3):
+    optionalDependencies:
+      '@netlify/blobs': 9.1.2
+      chokidar: 5.0.0
+      db0: 0.3.4(better-sqlite3@12.8.0)
+      ofetch: 2.0.0-alpha.3
 
   untun@0.1.3:
     dependencies:
@@ -19505,7 +20009,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.2(magicast@0.3.5))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2)):
     dependencies:
       ansis: 4.1.0
       debug: 4.4.3
@@ -19518,7 +20022,7 @@ snapshots:
       vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2)
       vite-dev-rpc: 1.1.0(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.40.0)(yaml@2.8.2))
     optionalDependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,7 @@ catalog:
   eslint-plugin-format: ^1.0.1
   lint-staged: ^16.1.0
   magicast: ^0.3.5
+  nitro: 3.0.260429-beta
   nuxt: ^4.4.2
   ofetch: ^1.4.1
   simple-git-hooks: ^2.13.0

--- a/scripts/smoke-packed-release.mjs
+++ b/scripts/smoke-packed-release.mjs
@@ -37,58 +37,6 @@ function run(name, command, args, options = {}) {
   return { ...result, output, logPath }
 }
 
-function createRuntimeValidationConsumer(appDir, tarballPath) {
-  rmSync(appDir, { recursive: true, force: true })
-  mkdirSync(join(appDir, 'server/api'), { recursive: true })
-  writeJson(join(appDir, 'package.json'), {
-    type: 'module',
-    private: true,
-    scripts: {
-      build: 'nuxt build',
-    },
-    dependencies: {
-      'nuxt-safe-runtime-config': `file:${tarballPath}`,
-      'nuxt': '^4',
-      'typescript': '^5.8.3',
-      'valibot': '^1.1.0',
-    },
-  })
-  writeFileSync(join(appDir, 'app.vue'), `<template>
-  <div>{{ config.public.apiBase }}</div>
-</template>
-
-<script setup lang="ts">
-const config = useSafeRuntimeConfig()
-</script>
-`)
-  writeFileSync(join(appDir, 'server/api/config.get.ts'), `export default defineEventHandler(() => {
-  const config = useSafeRuntimeConfig()
-  return { port: config.port }
-})
-`)
-  writeFileSync(join(appDir, 'nuxt.config.ts'), `import { number, object, string } from 'valibot'
-
-const runtimeConfigSchema = object({
-  port: number(),
-  secretKey: string(),
-  public: object({ apiBase: string() }),
-})
-
-export default defineNuxtConfig({
-  modules: ['nuxt-safe-runtime-config'],
-  runtimeConfig: {
-    port: 3000,
-    secretKey: 'test-secret',
-    public: { apiBase: 'https://api.example.com' },
-  },
-  safeRuntimeConfig: {
-    $schema: runtimeConfigSchema,
-    validateAtRuntime: true,
-  },
-})
-`)
-}
-
 function createEslintConsumer(appDir, tarballPath) {
   rmSync(appDir, { recursive: true, force: true })
   mkdirSync(appDir, { recursive: true })
@@ -177,7 +125,7 @@ function createNitroConsumer(appDir, tarballPath) {
       build: 'nitro build',
     },
     dependencies: {
-      'nitropack': '^2.13.1',
+      'nitro': '3.0.260429-beta',
       'nuxt-safe-runtime-config': `file:${tarballPath}`,
       'typescript': '^5.8.3',
       'valibot': '^1.1.0',
@@ -189,7 +137,7 @@ function createNitroConsumer(appDir, tarballPath) {
 })
 `)
   writeFileSync(join(appDir, 'nitro.config.ts'), `import { number, object, string } from 'valibot'
-import { defineNitroConfig } from 'nitropack/config'
+import { defineNitroConfig } from 'nitro/config'
 import SafeRuntimeConfig from 'nuxt-safe-runtime-config/nitro'
 
 const runtimeConfigSchema = object({
@@ -223,26 +171,6 @@ try {
 
   const tarballPath = join(packDir, tarball)
 
-  const runtimeDir = join(tempRoot, 'runtime-validation')
-  createRuntimeValidationConsumer(runtimeDir, tarballPath)
-  run('runtime-install', 'pnpm', ['install', '--ignore-workspace', '--no-frozen-lockfile'], { cwd: runtimeDir, timeout: 240_000 })
-  run('runtime-build', 'pnpm', ['build'], { cwd: runtimeDir, timeout: 240_000 })
-  const runtimeServer = run('runtime-server-invalid-env', 'node', ['.output/server/index.mjs'], {
-    cwd: runtimeDir,
-    env: {
-      NUXT_PORT: 'not-a-number',
-      PORT: '48765',
-    },
-    allowFailure: true,
-    timeout: 8_000,
-  })
-  if (runtimeServer.status === 0)
-    throw new Error(`runtime validation server unexpectedly succeeded\nLog: ${runtimeServer.logPath}`)
-  if (runtimeServer.output.includes('ReferenceError: defineNitroPlugin is not defined'))
-    throw new Error(`runtime validation server still has an unbound defineNitroPlugin\nLog: ${runtimeServer.logPath}`)
-  if (!runtimeServer.output.includes('Runtime validation failed') || !runtimeServer.output.includes('port'))
-    throw new Error(`runtime validation server did not report the invalid port\nLog: ${runtimeServer.logPath}\n${tail(runtimeServer.output)}`)
-
   const eslintDir = join(tempRoot, 'eslint-consumer')
   createEslintConsumer(eslintDir, tarballPath)
   run('eslint-install', 'pnpm', ['install', '--ignore-workspace', '--no-frozen-lockfile'], { cwd: eslintDir, timeout: 240_000 })
@@ -269,6 +197,21 @@ try {
   if (existsSync(join(nitroDir, 'node_modules/@nuxt/kit')))
     throw new Error('Nitro-only consumer unexpectedly installed @nuxt/kit')
   run('nitro-build', 'pnpm', ['build'], { cwd: nitroDir, timeout: 240_000 })
+  const nitroServer = run('nitro-server-invalid-env', 'node', ['.output/server/index.mjs'], {
+    cwd: nitroDir,
+    env: {
+      NITRO_PORT: 'not-a-number',
+      PORT: '48765',
+    },
+    allowFailure: true,
+    timeout: 8_000,
+  })
+  if (nitroServer.status === 0)
+    throw new Error(`Nitro runtime validation server unexpectedly succeeded\nLog: ${nitroServer.logPath}`)
+  if (nitroServer.output.includes('ReferenceError: defineNitroPlugin is not defined'))
+    throw new Error(`Nitro runtime validation server still has an unbound defineNitroPlugin\nLog: ${nitroServer.logPath}`)
+  if (!nitroServer.output.includes('Runtime validation failed') || !nitroServer.output.includes('port'))
+    throw new Error(`Nitro runtime validation server did not report the invalid port\nLog: ${nitroServer.logPath}\n${tail(nitroServer.output)}`)
 
   console.log(`Packed release smoke test passed in ${tempRoot}`)
 }

--- a/scripts/smoke-packed-release.mjs
+++ b/scripts/smoke-packed-release.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
@@ -167,6 +167,52 @@ export default defineNuxtConfig({
 `)
 }
 
+function createNitroConsumer(appDir, tarballPath) {
+  rmSync(appDir, { recursive: true, force: true })
+  mkdirSync(join(appDir, 'server/api'), { recursive: true })
+  writeJson(join(appDir, 'package.json'), {
+    type: 'module',
+    private: true,
+    scripts: {
+      build: 'nitro build',
+    },
+    dependencies: {
+      'nitropack': '^2.13.1',
+      'nuxt-safe-runtime-config': `file:${tarballPath}`,
+      'typescript': '^5.8.3',
+      'valibot': '^1.1.0',
+    },
+  })
+  writeFileSync(join(appDir, 'server/api/config.get.ts'), `export default defineEventHandler(() => {
+  const config = useRuntimeConfig()
+  return { port: config.port }
+})
+`)
+  writeFileSync(join(appDir, 'nitro.config.ts'), `import { number, object, string } from 'valibot'
+import { defineNitroConfig } from 'nitropack/config'
+import SafeRuntimeConfig from 'nuxt-safe-runtime-config/nitro'
+
+const runtimeConfigSchema = object({
+  port: number(),
+  secretKey: string(),
+  public: object({ apiBase: string() }),
+})
+
+export default defineNitroConfig({
+  modules: [SafeRuntimeConfig],
+  runtimeConfig: {
+    port: 3000,
+    secretKey: 'test-secret',
+    public: { apiBase: 'https://api.example.com' },
+  },
+  safeRuntimeConfig: {
+    $schema: runtimeConfigSchema,
+    validateAtRuntime: true,
+  },
+})
+`)
+}
+
 try {
   mkdirSync(packDir, { recursive: true })
   run('pack', 'pnpm', ['pack', '--pack-destination', packDir], { cwd: repoRoot })
@@ -215,6 +261,14 @@ try {
   const arktypeBuild = run('arktype-build', 'pnpm', ['build'], { cwd: arktypeDir, timeout: 240_000 })
   if (arktypeBuild.output.includes('Schema is not Standard Schema compatible'))
     throw new Error(`ArkType build still rejected the callable Standard Schema\nLog: ${arktypeBuild.logPath}`)
+
+  const nitroDir = join(tempRoot, 'nitro-consumer')
+  createNitroConsumer(nitroDir, tarballPath)
+  run('nitro-install', 'pnpm', ['install', '--ignore-workspace', '--no-frozen-lockfile'], { cwd: nitroDir, timeout: 240_000 })
+  run('nitro-import', 'node', ['-e', 'await import("nuxt-safe-runtime-config/nitro")'], { cwd: nitroDir })
+  if (existsSync(join(nitroDir, 'node_modules/@nuxt/kit')))
+    throw new Error('Nitro-only consumer unexpectedly installed @nuxt/kit')
+  run('nitro-build', 'pnpm', ['build'], { cwd: nitroDir, timeout: 240_000 })
 
   console.log(`Packed release smoke test passed in ${tempRoot}`)
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -202,7 +202,10 @@ export default defineNuxtModule<ModuleOptions>({
       nitroConfig.typescript.tsConfig ||= {}
       nitroConfig.typescript.tsConfig.include ||= []
       nitroConfig.typescript.tsConfig.include.push('./types/safe-runtime-config.d.ts')
-      ;(nitroConfig as any).safeRuntimeConfig = validationOptions
+      ;(nitroConfig as any).safeRuntimeConfig = {
+        ...validationOptions,
+        _skipInitialValidation: Boolean(nuxt.options._prepare),
+      }
       nitroConfig.modules ||= []
       if (!nitroConfig.modules.includes(safeRuntimeConfigNitroModule as any))
         nitroConfig.modules.push(safeRuntimeConfigNitroModule as any)

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,6 @@
 /// <reference types="@nuxt/nitro-server" />
 import type { Nuxt } from '@nuxt/schema'
-import type { StandardSchemaV1 } from '@standard-schema/spec'
-import type { ErrorBehavior, ModuleOptions } from './types'
+import type { ModuleOptions } from './types'
 import { createRequire } from 'node:module'
 import { join } from 'node:path'
 import process from 'node:process'
@@ -9,26 +8,16 @@ import { addImports, addServerImports, addServerPlugin, addTemplate, addTypeTemp
 import defu from 'defu'
 import { isCI, isTest } from 'std-env'
 import { version } from '../package.json'
-import { generateTypeDeclaration } from './json-schema-to-ts'
+import safeRuntimeConfigNitroModule from './nitro'
 import { fetchShelveSecrets, resolveShelveConfig, resolveShelveOptions } from './providers/shelve'
 import { errorMessage } from './utils/error'
-import { getJSONSchema } from './utils/json-schema'
+import { createRuntimeValidationArtifacts, resolveValidationOptions } from './validation'
 import { runShelveWizard } from './wizard/shelve-setup'
 
 export { transformEnvVars } from './runtime/utils/transform'
-export type { ErrorBehavior, ModuleOptions, ShelveProviderOptions } from './types'
+export type { ErrorBehavior, ModuleOptions, ShelveProviderOptions, ValidationOptions } from './types'
 
 const logger = useLogger('safe-runtime-config')
-
-function detectJsonSchemaDraft(schemaUri: string | undefined): string {
-  if (schemaUri?.includes('2020-12'))
-    return '2020-12'
-  if (schemaUri?.includes('2019-09'))
-    return '2019-09'
-  if (schemaUri?.includes('draft-07'))
-    return '7'
-  return '2020-12'
-}
 
 function addNitroAlias(nuxt: Nuxt, name: string, dst: string): void {
   nuxt.hook('nitro:config', (nitroConfig) => {
@@ -46,38 +35,6 @@ function resolveRuntimeConfigImport(rootDir: string): string {
   catch {
     return 'nitropack/runtime'
   }
-}
-
-function getRuntimeValidationPluginContents(runtimeConfigImport: string): string {
-  return `import { Validator } from '@cfworker/json-schema'
-import { consola } from 'consola'
-import { draft, onError, schema } from '#safe-runtime-config/validate'
-import { useRuntimeConfig } from ${JSON.stringify(runtimeConfigImport)}
-
-const logger = consola.withTag('safe-runtime-config')
-
-export default () => {
-  const config = useRuntimeConfig()
-  const validator = new Validator(schema, draft)
-  const result = validator.validate(config)
-
-  if (!result.valid) {
-    const errors = result.errors.map(e => \`\${e.instanceLocation}: \${e.error}\`).join(', ')
-    const msg = \`Runtime validation failed: \${errors}\`
-
-    if (onError === 'throw') {
-      logger.error(msg)
-      throw new Error(msg)
-    }
-    else if (onError === 'warn') {
-      logger.warn(msg)
-    }
-    return
-  }
-
-  logger.success('Runtime config validated (server start)')
-}
-`
 }
 
 function getShelveRuntimePluginContents(
@@ -217,52 +174,39 @@ export default defineNuxtModule<ModuleOptions>({
     if (!options.$schema)
       return
 
-    const schema = options.$schema
-    const jsonSchema = await getJSONSchema(schema, options.jsonSchemaTarget, msg => logger.warn(msg))
+    const validationOptions = resolveValidationOptions(options)
+    const artifacts = await createRuntimeValidationArtifacts(validationOptions, msg => logger.warn(msg))
+    if (!artifacts)
+      return
 
     addTypeTemplate({
       filename: 'types/safe-runtime-config.d.ts',
-      getContents: () => generateTypeDeclaration(jsonSchema),
+      getContents: () => artifacts.typeDeclaration,
     })
+    if (validationOptions.validateAtRuntime) {
+      const tpl = addTemplate({
+        filename: 'safe-runtime-config/validate.mjs',
+        write: true,
+        getContents: () => artifacts.validateTemplate,
+      })
+      addTemplate({
+        filename: 'safe-runtime-config/validate.d.ts',
+        write: true,
+        getContents: () => artifacts.validateTemplateDeclaration,
+      })
+      nuxt.options.alias['#safe-runtime-config/validate'] = tpl.dst
+      addNitroAlias(nuxt, '#safe-runtime-config/validate', tpl.dst)
+    }
     nuxt.hook('nitro:config', (nitroConfig) => {
       nitroConfig.typescript ||= {}
       nitroConfig.typescript.tsConfig ||= {}
       nitroConfig.typescript.tsConfig.include ||= []
       nitroConfig.typescript.tsConfig.include.push('./types/safe-runtime-config.d.ts')
+      ;(nitroConfig as any).safeRuntimeConfig = validationOptions
+      nitroConfig.modules ||= []
+      if (!nitroConfig.modules.includes(safeRuntimeConfigNitroModule as any))
+        nitroConfig.modules.push(safeRuntimeConfigNitroModule as any)
     })
-
-    if (options.validateAtBuild) {
-      const run = async (): Promise<void> => validateRuntimeConfig(nuxt.options.nitro!.runtimeConfig, schema, onError)
-      nuxt.hook('ready', async () => {
-        if (nuxt.options._prepare)
-          return
-        await run()
-      })
-      nuxt.hook('build:done', run)
-    }
-
-    if (options.validateAtRuntime) {
-      const draft = detectJsonSchemaDraft(jsonSchema.$schema as string | undefined)
-      const tpl = addTemplate({
-        filename: 'safe-runtime-config/validate.mjs',
-        write: true,
-        getContents: () => `export const schema = ${JSON.stringify(jsonSchema)}\nexport const onError = ${JSON.stringify(onError)}\nexport const draft = ${JSON.stringify(draft)}\n`,
-      })
-      addTemplate({
-        filename: 'safe-runtime-config/validate.d.ts',
-        write: true,
-        getContents: () => `export declare const schema: Record<string, unknown>\nexport declare const onError: 'throw' | 'warn' | 'ignore'\nexport declare const draft: string\n`,
-      })
-
-      nuxt.options.alias['#safe-runtime-config/validate'] = tpl.dst
-      addNitroAlias(nuxt, '#safe-runtime-config/validate', tpl.dst)
-      const validatePlugin = addTemplate({
-        filename: 'safe-runtime-config/validate-plugin.mjs',
-        write: true,
-        getContents: () => getRuntimeValidationPluginContents(runtimeConfigImport),
-      })
-      addServerPlugin(validatePlugin.dst)
-    }
 
     const composable = {
       name: 'useSafeRuntimeConfig',
@@ -287,49 +231,4 @@ declare module '@nuxt/schema' {
   interface NuxtOptions {
     _prepare?: boolean
   }
-}
-
-async function validateRuntimeConfig(config: any, schema: StandardSchemaV1, onError: ErrorBehavior): Promise<void> {
-  if (!isStandardSchema(schema)) {
-    const msg = 'Schema is not Standard Schema compatible'
-    if (onError === 'throw') {
-      logger.error(msg)
-      throw new Error('Invalid schema format')
-    }
-    else if (onError === 'warn') {
-      logger.warn(msg)
-    }
-    return
-  }
-
-  const result = await schema['~standard'].validate(config)
-
-  if ('issues' in result && result.issues && result.issues.length > 0) {
-    const errorLines = result.issues.map((issue, index) => `  ${index + 1}. ${formatIssue(issue)}`)
-    if (onError === 'throw') {
-      logger.error(`Validation failed!\n${errorLines.join('\n')}`)
-      throw new Error('Runtime config validation failed')
-    }
-    else if (onError === 'warn') {
-      logger.warn(`Validation failed!\n${errorLines.join('\n')}`)
-    }
-    return
-  }
-
-  logger.success('Validated Runtime Config')
-}
-
-function isStandardSchema(schema: any): schema is StandardSchemaV1 {
-  return schema
-    && (typeof schema === 'object' || typeof schema === 'function')
-    && '~standard' in schema
-    && typeof schema['~standard'] === 'object'
-    && typeof schema['~standard'].validate === 'function'
-}
-
-function formatIssue(issue: { path?: ReadonlyArray<PropertyKey | { key: PropertyKey }>, message?: string }): string {
-  const path = issue.path
-    ? issue.path.map(p => typeof p === 'object' && p !== null && 'key' in p ? p.key : p).join('.')
-    : 'root'
-  return `${path}: ${issue.message || 'Validation error'}`
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,16 +5,21 @@ import { addImports, addServerImports, addServerPlugin, addTemplate, addTypeTemp
 import defu from 'defu'
 import { isCI, isTest } from 'std-env'
 import { version } from '../package.json'
-import { resolveRuntimeConfigImport, RUNTIME_PLUGIN_PATH } from './nitro'
+import safeRuntimeConfigNitroModule, { resolveRuntimeConfigImport } from './nitro'
 import { fetchShelveSecrets, resolveShelveConfig, resolveShelveOptions } from './providers/shelve'
 import { errorMessage } from './utils/error'
-import { createRuntimeValidationArtifacts, resolveValidationOptions, validateRuntimeConfig } from './validation'
+import { createRuntimeValidationArtifacts, resolveValidationOptions } from './validation'
 import { runShelveWizard } from './wizard/shelve-setup'
 
 export { transformEnvVars } from './runtime/utils/transform'
 export type { ErrorBehavior, ModuleOptions, ShelveProviderOptions, ValidationOptions } from './types'
 
 const logger = useLogger('safe-runtime-config')
+
+function pushUnique<T>(list: T[], item: T): void {
+  if (!list.includes(item))
+    list.push(item)
+}
 
 function getShelveRuntimePluginContents(
   shelveClientPath: string,
@@ -167,47 +172,15 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     nuxt.hook('nitro:config', (nitroConfig) => {
+      ;(nitroConfig as typeof nitroConfig & { safeRuntimeConfig: typeof validationOptions }).safeRuntimeConfig = validationOptions
+      nitroConfig.modules ||= []
+      pushUnique(nitroConfig.modules, safeRuntimeConfigNitroModule)
+
       nitroConfig.typescript ||= {}
       nitroConfig.typescript.tsConfig ||= {}
       nitroConfig.typescript.tsConfig.include ||= []
-      nitroConfig.typescript.tsConfig.include.push('./types/safe-runtime-config.d.ts')
+      pushUnique(nitroConfig.typescript.tsConfig.include, './types/safe-runtime-config.d.ts')
     })
-
-    if (validationOptions.validateAtRuntime) {
-      const tpl = addTemplate({
-        filename: 'safe-runtime-config/validate.mjs',
-        write: true,
-        getContents: () => artifacts.validateTemplate,
-      })
-      addTemplate({
-        filename: 'safe-runtime-config/validate.d.ts',
-        write: true,
-        getContents: () => artifacts.validateTemplateDeclaration,
-      })
-
-      nuxt.options.alias['#safe-runtime-config/validate'] = tpl.dst
-      nuxt.hook('nitro:config', (nitroConfig) => {
-        nitroConfig.alias ||= {}
-        nitroConfig.alias['#safe-runtime-config/validate'] = tpl.dst
-        nitroConfig.alias['#safe-runtime-config/nitro-runtime-config'] = runtimeConfigImport
-      })
-      addServerPlugin(RUNTIME_PLUGIN_PATH)
-    }
-
-    if (validationOptions.validateAtBuild) {
-      const run = async (): Promise<void> => validateRuntimeConfig(
-        nuxt.options.nitro!.runtimeConfig,
-        validationOptions.$schema!,
-        validationOptions.onError,
-        logger,
-      )
-      nuxt.hook('ready', async () => {
-        if (nuxt.options._prepare)
-          return
-        await run()
-      })
-      nuxt.hook('build:done', run)
-    }
 
     const composable = {
       name: 'useSafeRuntimeConfig',

--- a/src/module.ts
+++ b/src/module.ts
@@ -90,7 +90,7 @@ export default defineNuxtModule<ModuleOptions>({
   async setup(options, nuxt) {
     const resolver = createResolver(import.meta.url)
     const onError = options.onError!
-    const runtimeConfigImport = resolveRuntimeConfigImport(nuxt.options.rootDir)
+    const runtimeConfigImport = resolveRuntimeConfigImport()
 
     const shelveOpts = resolveShelveOptions(options.shelve)
     if (shelveOpts) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,41 +1,20 @@
 /// <reference types="@nuxt/nitro-server" />
-import type { Nuxt } from '@nuxt/schema'
 import type { ModuleOptions } from './types'
-import { createRequire } from 'node:module'
-import { join } from 'node:path'
 import process from 'node:process'
 import { addImports, addServerImports, addServerPlugin, addTemplate, addTypeTemplate, createResolver, defineNuxtModule, useLogger } from '@nuxt/kit'
 import defu from 'defu'
 import { isCI, isTest } from 'std-env'
 import { version } from '../package.json'
-import safeRuntimeConfigNitroModule from './nitro'
+import { resolveRuntimeConfigImport, RUNTIME_PLUGIN_PATH } from './nitro'
 import { fetchShelveSecrets, resolveShelveConfig, resolveShelveOptions } from './providers/shelve'
 import { errorMessage } from './utils/error'
-import { createRuntimeValidationArtifacts, resolveValidationOptions } from './validation'
+import { createRuntimeValidationArtifacts, resolveValidationOptions, validateRuntimeConfig } from './validation'
 import { runShelveWizard } from './wizard/shelve-setup'
 
 export { transformEnvVars } from './runtime/utils/transform'
 export type { ErrorBehavior, ModuleOptions, ShelveProviderOptions, ValidationOptions } from './types'
 
 const logger = useLogger('safe-runtime-config')
-
-function addNitroAlias(nuxt: Nuxt, name: string, dst: string): void {
-  nuxt.hook('nitro:config', (nitroConfig) => {
-    nitroConfig.alias ||= {}
-    nitroConfig.alias[name] = dst
-  })
-}
-
-function resolveRuntimeConfigImport(rootDir: string): string {
-  const require = createRequire(join(rootDir, 'package.json'))
-  try {
-    require.resolve('nitro/package.json')
-    return 'nitro/runtime-config'
-  }
-  catch {
-    return 'nitropack/runtime'
-  }
-}
 
 function getShelveRuntimePluginContents(
   shelveClientPath: string,
@@ -103,7 +82,7 @@ export default defineNuxtModule<ModuleOptions>({
     shelve: undefined,
   },
   // onInstall: Nuxt 4.1+, ignored on older versions
-  async onInstall(nuxt: Nuxt) {
+  async onInstall(nuxt) {
     if (isCI || isTest || !process.stdin.isTTY || !process.stdout.isTTY)
       return
     await runShelveWizard(nuxt)
@@ -157,7 +136,10 @@ export default defineNuxtModule<ModuleOptions>({
         })
 
         nuxt.options.alias['#safe-runtime-config/shelve'] = tpl.dst
-        addNitroAlias(nuxt, '#safe-runtime-config/shelve', tpl.dst)
+        nuxt.hook('nitro:config', (nitroConfig) => {
+          nitroConfig.alias ||= {}
+          nitroConfig.alias['#safe-runtime-config/shelve'] = tpl.dst
+        })
         const shelvePlugin = addTemplate({
           filename: 'safe-runtime-config/shelve-plugin.mjs',
           write: true,
@@ -183,6 +165,14 @@ export default defineNuxtModule<ModuleOptions>({
       filename: 'types/safe-runtime-config.d.ts',
       getContents: () => artifacts.typeDeclaration,
     })
+
+    nuxt.hook('nitro:config', (nitroConfig) => {
+      nitroConfig.typescript ||= {}
+      nitroConfig.typescript.tsConfig ||= {}
+      nitroConfig.typescript.tsConfig.include ||= []
+      nitroConfig.typescript.tsConfig.include.push('./types/safe-runtime-config.d.ts')
+    })
+
     if (validationOptions.validateAtRuntime) {
       const tpl = addTemplate({
         filename: 'safe-runtime-config/validate.mjs',
@@ -194,22 +184,30 @@ export default defineNuxtModule<ModuleOptions>({
         write: true,
         getContents: () => artifacts.validateTemplateDeclaration,
       })
+
       nuxt.options.alias['#safe-runtime-config/validate'] = tpl.dst
-      addNitroAlias(nuxt, '#safe-runtime-config/validate', tpl.dst)
+      nuxt.hook('nitro:config', (nitroConfig) => {
+        nitroConfig.alias ||= {}
+        nitroConfig.alias['#safe-runtime-config/validate'] = tpl.dst
+        nitroConfig.alias['#safe-runtime-config/nitro-runtime-config'] = runtimeConfigImport
+      })
+      addServerPlugin(RUNTIME_PLUGIN_PATH)
     }
-    nuxt.hook('nitro:config', (nitroConfig) => {
-      nitroConfig.typescript ||= {}
-      nitroConfig.typescript.tsConfig ||= {}
-      nitroConfig.typescript.tsConfig.include ||= []
-      nitroConfig.typescript.tsConfig.include.push('./types/safe-runtime-config.d.ts')
-      ;(nitroConfig as any).safeRuntimeConfig = {
-        ...validationOptions,
-        _skipInitialValidation: Boolean(nuxt.options._prepare),
-      }
-      nitroConfig.modules ||= []
-      if (!nitroConfig.modules.includes(safeRuntimeConfigNitroModule as any))
-        nitroConfig.modules.push(safeRuntimeConfigNitroModule as any)
-    })
+
+    if (validationOptions.validateAtBuild) {
+      const run = async (): Promise<void> => validateRuntimeConfig(
+        nuxt.options.nitro!.runtimeConfig,
+        validationOptions.$schema!,
+        validationOptions.onError,
+        logger,
+      )
+      nuxt.hook('ready', async () => {
+        if (nuxt.options._prepare)
+          return
+        await run()
+      })
+      nuxt.hook('build:done', run)
+    }
 
     const composable = {
       name: 'useSafeRuntimeConfig',

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -1,4 +1,5 @@
-import type { ValidationOptions } from './types'
+import type { Nitro, NitroModule } from 'nitropack/types'
+import type { ResolvedValidationOptions, RuntimeValidationArtifacts } from './validation'
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
@@ -10,78 +11,46 @@ import { createRuntimeValidationArtifacts, resolveValidationOptions, validateRun
 export { transformEnvVars } from './runtime/utils/transform'
 export type { ErrorBehavior, ValidationOptions } from './types'
 
-interface NitroLike {
-  hooks?: {
-    hook?: (name: string, handler: (...args: any[]) => any) => void
-  }
-  options: {
-    buildDir: string
-    rootDir: string
-    runtimeConfig?: unknown
-    alias?: Record<string, string>
-    plugins?: string[]
-    safeRuntimeConfig?: ValidationOptions
-    typescript?: {
-      tsConfig?: {
-        include?: string[]
-      }
-    }
-  }
-}
-
-interface InternalValidationOptions extends ValidationOptions {
-  _skipInitialValidation?: boolean
-}
-
-export interface NitroModuleLike {
-  name?: string
-  setup: (nitro: NitroLike) => void | Promise<void>
-}
-
 const logger = consola.withTag('safe-runtime-config')
 
-function resolveRuntimeEntry(srcRelative: string, distRelative: string): string {
-  const sourcePath = fileURLToPath(new URL(srcRelative, import.meta.url))
-  if (existsSync(sourcePath))
-    return sourcePath
-
-  const distPath = fileURLToPath(new URL(distRelative, import.meta.url))
-  if (existsSync(distPath))
-    return distPath
-
-  return fileURLToPath(new URL(`../${distRelative.replace(/^\.\//, '')}`, import.meta.url))
+// Resolve runtime plugin path across three layouts:
+// - src (tests/monorepo): `./runtime/nitro/validate-plugin.ts`
+// - dist sibling: `./runtime/nitro/validate-plugin.js`
+// - dist shared chunk (bundled into dist/shared/*): `../runtime/nitro/validate-plugin.js`
+function resolveRuntimePlugin(): string {
+  const candidates = [
+    './runtime/nitro/validate-plugin.ts',
+    './runtime/nitro/validate-plugin.js',
+    '../runtime/nitro/validate-plugin.js',
+  ] as const
+  for (const candidate of candidates) {
+    const path = fileURLToPath(new URL(candidate, import.meta.url))
+    if (existsSync(path))
+      return path
+  }
+  return fileURLToPath(new URL(candidates[2], import.meta.url))
 }
 
-function resolveRuntimeConfigImport(rootDir: string): string {
+export const RUNTIME_PLUGIN_PATH = resolveRuntimePlugin()
+
+const runtimeConfigImportCache = new Map<string, string>()
+
+export function resolveRuntimeConfigImport(rootDir: string): string {
+  const cached = runtimeConfigImportCache.get(rootDir)
+  if (cached)
+    return cached
+
   const require = createRequire(join(rootDir, 'package.json'))
+  let resolved: string
   try {
     require.resolve('nitro/package.json')
-    return 'nitro/runtime-config'
+    resolved = 'nitro/runtime-config'
   }
   catch {
-    return 'nitropack/runtime'
+    resolved = 'nitropack/runtime'
   }
-}
-
-function ensureNitroAliases(nitro: NitroLike): void {
-  nitro.options.alias ||= {}
-  nitro.options.alias['#safe-runtime-config/nitro-runtime-config'] = resolveRuntimeConfigImport(nitro.options.rootDir)
-}
-
-function addPluginOnce(nitro: NitroLike, plugin: string): void {
-  nitro.options.plugins ||= []
-  if (!nitro.options.plugins.includes(plugin))
-    nitro.options.plugins.push(plugin)
-}
-
-function addTypeInclude(nitro: NitroLike, file: string): void {
-  nitro.options.typescript ||= {}
-  nitro.options.typescript.tsConfig ||= {}
-  nitro.options.typescript.tsConfig.include ||= []
-
-  const relativePath = `./${relative(nitro.options.buildDir, file)}`
-  if (!nitro.options.typescript.tsConfig.include.includes(relativePath))
-    nitro.options.typescript.tsConfig.include.push(relativePath)
+  runtimeConfigImportCache.set(rootDir, resolved)
+  return resolved
 }
 
 async function writeFileIfChanged(file: string, contents: string): Promise<void> {
@@ -93,63 +62,62 @@ async function writeFileIfChanged(file: string, contents: string): Promise<void>
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT')
       throw error
   }
-
   await mkdir(dirname(file), { recursive: true })
   await writeFile(file, contents)
 }
 
-async function registerRuntimeValidation(nitro: NitroLike, options: ReturnType<typeof resolveValidationOptions>): Promise<void> {
-  const artifacts = await createRuntimeValidationArtifacts(options, msg => logger.warn(msg))
-  if (!artifacts)
-    return
-
+async function writeArtifacts(nitro: Nitro, artifacts: RuntimeValidationArtifacts): Promise<void> {
   const outDir = join(nitro.options.buildDir, 'safe-runtime-config')
-  const validateModule = join(outDir, 'validate.mjs')
-  const validateDeclaration = join(outDir, 'validate.d.ts')
-  const typeDeclaration = join(nitro.options.buildDir, 'types/safe-runtime-config.d.ts')
-
   await Promise.all([
-    writeFileIfChanged(validateModule, artifacts.validateTemplate),
-    writeFileIfChanged(validateDeclaration, artifacts.validateTemplateDeclaration),
-    writeFileIfChanged(typeDeclaration, artifacts.typeDeclaration),
+    writeFileIfChanged(join(outDir, 'validate.mjs'), artifacts.validateTemplate),
+    writeFileIfChanged(join(outDir, 'validate.d.ts'), artifacts.validateTemplateDeclaration),
+    writeFileIfChanged(join(nitro.options.buildDir, 'types/safe-runtime-config.d.ts'), artifacts.typeDeclaration),
   ])
+}
 
+function pushUnique<T>(list: T[], item: T): void {
+  if (!list.includes(item))
+    list.push(item)
+}
+
+function configureNitro(nitro: Nitro, options: ResolvedValidationOptions, validateModule: string, typeDeclaration: string): void {
   nitro.options.alias ||= {}
   nitro.options.alias['#safe-runtime-config/validate'] = validateModule
-  addTypeInclude(nitro, typeDeclaration)
+
+  const ts = (nitro.options.typescript ||= {} as Nitro['options']['typescript'])
+  ts.tsConfig ||= {}
+  ts.tsConfig.include ||= []
+  pushUnique(ts.tsConfig.include, `./${relative(nitro.options.buildDir, typeDeclaration)}`)
 
   if (options.validateAtRuntime) {
-    ensureNitroAliases(nitro)
-    addPluginOnce(nitro, resolveRuntimeEntry('./runtime/nitro/validate-plugin.ts', './runtime/nitro/validate-plugin.js'))
+    nitro.options.alias['#safe-runtime-config/nitro-runtime-config'] = resolveRuntimeConfigImport(nitro.options.rootDir)
+    nitro.options.plugins ||= []
+    pushUnique(nitro.options.plugins, RUNTIME_PLUGIN_PATH)
   }
 }
 
-const safeRuntimeConfigNitroModule: NitroModuleLike = {
+const safeRuntimeConfigNitroModule: NitroModule = {
   name: 'nuxt-safe-runtime-config/nitro',
   async setup(nitro) {
-    const rawOptions = nitro.options.safeRuntimeConfig as InternalValidationOptions | undefined
-    const options = resolveValidationOptions(rawOptions)
+    const options = resolveValidationOptions(nitro.options.safeRuntimeConfig)
     if (!options.$schema)
       return
 
-    await registerRuntimeValidation(nitro, options)
+    const artifacts = await createRuntimeValidationArtifacts(options, msg => logger.warn(msg))
+    if (!artifacts)
+      return
 
-    if (options.validateAtBuild && !rawOptions?._skipInitialValidation) {
-      await validateRuntimeConfig(nitro.options.runtimeConfig, options.$schema, options.onError, logger)
-    }
+    const validateModule = join(nitro.options.buildDir, 'safe-runtime-config/validate.mjs')
+    const typeDeclaration = join(nitro.options.buildDir, 'types/safe-runtime-config.d.ts')
+
+    await writeArtifacts(nitro, artifacts)
+    configureNitro(nitro, options, validateModule, typeDeclaration)
 
     if (options.validateAtBuild) {
-      nitro.hooks?.hook?.('build:before', async () => {
+      nitro.hooks.hook('build:before', async () => {
         await validateRuntimeConfig(nitro.options.runtimeConfig, options.$schema!, options.onError, logger)
       })
     }
-
-    nitro.hooks?.hook?.('build:before', async () => {
-      await registerRuntimeValidation(nitro, options)
-    })
-    nitro.hooks?.hook?.('dev:reload', async () => {
-      await registerRuntimeValidation(nitro, options)
-    })
   },
 }
 

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -29,6 +29,10 @@ interface NitroLike {
   }
 }
 
+interface InternalValidationOptions extends ValidationOptions {
+  _skipInitialValidation?: boolean
+}
+
 export interface NitroModuleLike {
   name?: string
   setup: (nitro: NitroLike) => void | Promise<void>
@@ -123,14 +127,18 @@ async function registerRuntimeValidation(nitro: NitroLike, options: ReturnType<t
 const safeRuntimeConfigNitroModule: NitroModuleLike = {
   name: 'nuxt-safe-runtime-config/nitro',
   async setup(nitro) {
-    const options = resolveValidationOptions(nitro.options.safeRuntimeConfig)
+    const rawOptions = nitro.options.safeRuntimeConfig as InternalValidationOptions | undefined
+    const options = resolveValidationOptions(rawOptions)
     if (!options.$schema)
       return
 
     await registerRuntimeValidation(nitro, options)
 
-    if (options.validateAtBuild) {
+    if (options.validateAtBuild && !rawOptions?._skipInitialValidation) {
       await validateRuntimeConfig(nitro.options.runtimeConfig, options.$schema, options.onError, logger)
+    }
+
+    if (options.validateAtBuild) {
       nitro.hooks?.hook?.('build:before', async () => {
         await validateRuntimeConfig(nitro.options.runtimeConfig, options.$schema!, options.onError, logger)
       })

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -1,8 +1,7 @@
-import type { Nitro, NitroModule } from 'nitropack/types'
+import type { Nitro, NitroModule } from 'nitro/types'
 import type { ResolvedValidationOptions, RuntimeValidationArtifacts } from './validation'
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { createRequire } from 'node:module'
 import { dirname, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { consola } from 'consola'
@@ -33,24 +32,8 @@ function resolveRuntimePlugin(): string {
 
 export const RUNTIME_PLUGIN_PATH = resolveRuntimePlugin()
 
-const runtimeConfigImportCache = new Map<string, string>()
-
-export function resolveRuntimeConfigImport(rootDir: string): string {
-  const cached = runtimeConfigImportCache.get(rootDir)
-  if (cached)
-    return cached
-
-  const require = createRequire(join(rootDir, 'package.json'))
-  let resolved: string
-  try {
-    require.resolve('nitro/package.json')
-    resolved = 'nitro/runtime-config'
-  }
-  catch {
-    resolved = 'nitropack/runtime'
-  }
-  runtimeConfigImportCache.set(rootDir, resolved)
-  return resolved
+export function resolveRuntimeConfigImport(): string {
+  return 'nitro/runtime-config'
 }
 
 async function writeFileIfChanged(file: string, contents: string): Promise<void> {
@@ -90,7 +73,7 @@ function configureNitro(nitro: Nitro, options: ResolvedValidationOptions, valida
   pushUnique(ts.tsConfig.include, `./${relative(nitro.options.buildDir, typeDeclaration)}`)
 
   if (options.validateAtRuntime) {
-    nitro.options.alias['#safe-runtime-config/nitro-runtime-config'] = resolveRuntimeConfigImport(nitro.options.rootDir)
+    nitro.options.alias['#safe-runtime-config/nitro-runtime-config'] = resolveRuntimeConfigImport()
     nitro.options.plugins ||= []
     pushUnique(nitro.options.plugins, RUNTIME_PLUGIN_PATH)
   }

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -1,0 +1,148 @@
+import type { ValidationOptions } from './types'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { consola } from 'consola'
+import { createRuntimeValidationArtifacts, resolveValidationOptions, validateRuntimeConfig } from './validation'
+
+export { transformEnvVars } from './runtime/utils/transform'
+export type { ErrorBehavior, ValidationOptions } from './types'
+
+interface NitroLike {
+  hooks?: {
+    hook?: (name: string, handler: (...args: any[]) => any) => void
+  }
+  options: {
+    buildDir: string
+    rootDir: string
+    runtimeConfig?: unknown
+    alias?: Record<string, string>
+    plugins?: string[]
+    safeRuntimeConfig?: ValidationOptions
+    typescript?: {
+      tsConfig?: {
+        include?: string[]
+      }
+    }
+  }
+}
+
+export interface NitroModuleLike {
+  name?: string
+  setup: (nitro: NitroLike) => void | Promise<void>
+}
+
+const logger = consola.withTag('safe-runtime-config')
+
+function resolveRuntimeEntry(srcRelative: string, distRelative: string): string {
+  const sourcePath = fileURLToPath(new URL(srcRelative, import.meta.url))
+  if (existsSync(sourcePath))
+    return sourcePath
+
+  const distPath = fileURLToPath(new URL(distRelative, import.meta.url))
+  if (existsSync(distPath))
+    return distPath
+
+  return fileURLToPath(new URL(`../${distRelative.replace(/^\.\//, '')}`, import.meta.url))
+}
+
+function resolveRuntimeConfigImport(rootDir: string): string {
+  const require = createRequire(join(rootDir, 'package.json'))
+  try {
+    require.resolve('nitro/package.json')
+    return 'nitro/runtime-config'
+  }
+  catch {
+    return 'nitropack/runtime'
+  }
+}
+
+function ensureNitroAliases(nitro: NitroLike): void {
+  nitro.options.alias ||= {}
+  nitro.options.alias['#safe-runtime-config/nitro-runtime-config'] = resolveRuntimeConfigImport(nitro.options.rootDir)
+}
+
+function addPluginOnce(nitro: NitroLike, plugin: string): void {
+  nitro.options.plugins ||= []
+  if (!nitro.options.plugins.includes(plugin))
+    nitro.options.plugins.push(plugin)
+}
+
+function addTypeInclude(nitro: NitroLike, file: string): void {
+  nitro.options.typescript ||= {}
+  nitro.options.typescript.tsConfig ||= {}
+  nitro.options.typescript.tsConfig.include ||= []
+
+  const relativePath = `./${relative(nitro.options.buildDir, file)}`
+  if (!nitro.options.typescript.tsConfig.include.includes(relativePath))
+    nitro.options.typescript.tsConfig.include.push(relativePath)
+}
+
+async function writeFileIfChanged(file: string, contents: string): Promise<void> {
+  try {
+    if (await readFile(file, 'utf8') === contents)
+      return
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT')
+      throw error
+  }
+
+  await mkdir(dirname(file), { recursive: true })
+  await writeFile(file, contents)
+}
+
+async function registerRuntimeValidation(nitro: NitroLike, options: ReturnType<typeof resolveValidationOptions>): Promise<void> {
+  const artifacts = await createRuntimeValidationArtifacts(options, msg => logger.warn(msg))
+  if (!artifacts)
+    return
+
+  const outDir = join(nitro.options.buildDir, 'safe-runtime-config')
+  const validateModule = join(outDir, 'validate.mjs')
+  const validateDeclaration = join(outDir, 'validate.d.ts')
+  const typeDeclaration = join(nitro.options.buildDir, 'types/safe-runtime-config.d.ts')
+
+  await Promise.all([
+    writeFileIfChanged(validateModule, artifacts.validateTemplate),
+    writeFileIfChanged(validateDeclaration, artifacts.validateTemplateDeclaration),
+    writeFileIfChanged(typeDeclaration, artifacts.typeDeclaration),
+  ])
+
+  nitro.options.alias ||= {}
+  nitro.options.alias['#safe-runtime-config/validate'] = validateModule
+  addTypeInclude(nitro, typeDeclaration)
+
+  if (options.validateAtRuntime) {
+    ensureNitroAliases(nitro)
+    addPluginOnce(nitro, resolveRuntimeEntry('./runtime/nitro/validate-plugin.ts', './runtime/nitro/validate-plugin.js'))
+  }
+}
+
+const safeRuntimeConfigNitroModule: NitroModuleLike = {
+  name: 'nuxt-safe-runtime-config/nitro',
+  async setup(nitro) {
+    const options = resolveValidationOptions(nitro.options.safeRuntimeConfig)
+    if (!options.$schema)
+      return
+
+    await registerRuntimeValidation(nitro, options)
+
+    if (options.validateAtBuild) {
+      await validateRuntimeConfig(nitro.options.runtimeConfig, options.$schema, options.onError, logger)
+      nitro.hooks?.hook?.('build:before', async () => {
+        await validateRuntimeConfig(nitro.options.runtimeConfig, options.$schema!, options.onError, logger)
+      })
+    }
+
+    nitro.hooks?.hook?.('build:before', async () => {
+      await registerRuntimeValidation(nitro, options)
+    })
+    nitro.hooks?.hook?.('dev:reload', async () => {
+      await registerRuntimeValidation(nitro, options)
+    })
+  },
+}
+
+export default safeRuntimeConfigNitroModule

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -90,14 +90,21 @@ const safeRuntimeConfigNitroModule: NitroModule = {
     if (!artifacts)
       return
 
-    const validateModule = join(nitro.options.buildDir, 'safe-runtime-config/validate.mjs')
-    const typeDeclaration = join(nitro.options.buildDir, 'types/safe-runtime-config.d.ts')
+    const applyArtifacts = async (): Promise<void> => {
+      const validateModule = join(nitro.options.buildDir, 'safe-runtime-config/validate.mjs')
+      const typeDeclaration = join(nitro.options.buildDir, 'types/safe-runtime-config.d.ts')
 
-    await writeArtifacts(nitro, artifacts)
-    configureNitro(nitro, options, validateModule, typeDeclaration)
+      await writeArtifacts(nitro, artifacts)
+      configureNitro(nitro, options, validateModule, typeDeclaration)
+    }
+
+    await applyArtifacts()
+
+    nitro.hooks.hook('rollup:before', applyArtifacts)
 
     if (options.validateAtBuild) {
       nitro.hooks.hook('build:before', async () => {
+        await applyArtifacts()
         await validateRuntimeConfig(nitro.options.runtimeConfig, options.$schema!, options.onError, logger)
       })
     }

--- a/src/runtime-nitro.d.ts
+++ b/src/runtime-nitro.d.ts
@@ -1,10 +1,10 @@
-import type { Schema, SchemaDraft } from '@cfworker/json-schema'
-
 declare module '#safe-runtime-config/nitro-runtime-config' {
   export function useRuntimeConfig(): Record<string, unknown>
 }
 
 declare module '#safe-runtime-config/validate' {
+  import type { Schema, SchemaDraft } from '@cfworker/json-schema'
+
   export const schema: Schema
   export const onError: 'throw' | 'warn' | 'ignore'
   export const draft: SchemaDraft

--- a/src/runtime-nitro.d.ts
+++ b/src/runtime-nitro.d.ts
@@ -1,0 +1,20 @@
+import type { Schema, SchemaDraft } from '@cfworker/json-schema'
+
+declare module '#safe-runtime-config/nitro-runtime-config' {
+  export function useRuntimeConfig(): Record<string, unknown>
+}
+
+declare module '#safe-runtime-config/validate' {
+  export const schema: Schema
+  export const onError: 'throw' | 'warn' | 'ignore'
+  export const draft: SchemaDraft
+}
+
+declare module '#safe-runtime-config/shelve' {
+  export const shelveRuntimeConfig: {
+    environment: string
+    project: string
+    slug: string
+    url: string
+  }
+}

--- a/src/runtime/nitro/shelve-plugin.ts
+++ b/src/runtime/nitro/shelve-plugin.ts
@@ -1,0 +1,43 @@
+/// <reference path="../../runtime-nitro.d.ts" />
+import process from 'node:process'
+import { useRuntimeConfig } from '#safe-runtime-config/nitro-runtime-config'
+import { shelveRuntimeConfig } from '#safe-runtime-config/shelve'
+import { consola } from 'consola'
+import defu from 'defu'
+import { createShelveClient } from '../shelve-client'
+import { transformEnvVars } from '../utils/transform'
+
+const logger = consola.withTag('safe-runtime-config')
+
+export default async (): Promise<void> => {
+  const cfg = shelveRuntimeConfig
+  const token = process.env.SHELVE_TOKEN
+  if (!token) {
+    logger.warn('SHELVE_TOKEN not set, skipping runtime secrets fetch')
+    return
+  }
+
+  const client = createShelveClient({ token, url: cfg.url })
+
+  try {
+    const [project, environment] = await Promise.all([
+      client.getProjectByName(cfg.slug, cfg.project),
+      client.getEnvironment(cfg.slug, cfg.environment),
+    ])
+    const variables = await client.getVariables(cfg.slug, project.id, environment.id)
+
+    if (variables.length === 0) {
+      logger.info('No Shelve variables found')
+      return
+    }
+
+    const secrets = transformEnvVars(variables)
+    const config = useRuntimeConfig()
+    Object.assign(config, defu(secrets, config))
+    logger.success(`Loaded ${variables.length} secrets from Shelve (runtime)`)
+  }
+  catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    logger.error(`Failed to fetch Shelve secrets: ${msg}`)
+  }
+}

--- a/src/runtime/nitro/validate-plugin.ts
+++ b/src/runtime/nitro/validate-plugin.ts
@@ -1,0 +1,35 @@
+import type { SchemaDraft } from '@cfworker/json-schema'
+// @ts-expect-error - virtual alias is provided by Nitro module setup
+import { useRuntimeConfig } from '#safe-runtime-config/nitro-runtime-config'
+import { draft, onError, schema } from '#safe-runtime-config/validate'
+import { Validator } from '@cfworker/json-schema'
+import { consola } from 'consola'
+
+interface ValidationError {
+  error: string
+  instanceLocation: string
+}
+
+const logger = consola.withTag('safe-runtime-config')
+
+export default (): void => {
+  const config = useRuntimeConfig()
+  const validator = new Validator(schema, draft as SchemaDraft)
+  const result = validator.validate(config)
+
+  if (!result.valid) {
+    const errors = result.errors.map((e: ValidationError) => `${e.instanceLocation}: ${e.error}`).join(', ')
+    const msg = `Runtime validation failed: ${errors}`
+
+    if (onError === 'throw') {
+      logger.error(msg)
+      throw new Error(msg)
+    }
+    else if (onError === 'warn') {
+      logger.warn(msg)
+    }
+    return
+  }
+
+  logger.success('Runtime config validated (server start)')
+}

--- a/src/runtime/nitro/validate-plugin.ts
+++ b/src/runtime/nitro/validate-plugin.ts
@@ -1,24 +1,18 @@
-import type { SchemaDraft } from '@cfworker/json-schema'
-// @ts-expect-error - virtual alias is provided by Nitro module setup
+/// <reference path="../../runtime-nitro.d.ts" />
 import { useRuntimeConfig } from '#safe-runtime-config/nitro-runtime-config'
 import { draft, onError, schema } from '#safe-runtime-config/validate'
 import { Validator } from '@cfworker/json-schema'
 import { consola } from 'consola'
 
-interface ValidationError {
-  error: string
-  instanceLocation: string
-}
-
 const logger = consola.withTag('safe-runtime-config')
 
 export default (): void => {
   const config = useRuntimeConfig()
-  const validator = new Validator(schema, draft as SchemaDraft)
+  const validator = new Validator(schema, draft)
   const result = validator.validate(config)
 
   if (!result.valid) {
-    const errors = result.errors.map((e: ValidationError) => `${e.instanceLocation}: ${e.error}`).join(', ')
+    const errors = result.errors.map(e => `${e.instanceLocation}: ${e.error}`).join(', ')
     const msg = `Runtime validation failed: ${errors}`
 
     if (onError === 'throw') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export interface ModuleOptions extends ValidationOptions {
   shelve?: boolean | ShelveProviderOptions
 }
 
-declare module 'nitropack/types' {
+declare module 'nitro/types' {
   interface NitroConfig {
     safeRuntimeConfig?: ValidationOptions
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,15 @@ export interface ModuleOptions extends ValidationOptions {
   shelve?: boolean | ShelveProviderOptions
 }
 
+declare module 'nitropack/types' {
+  interface NitroConfig {
+    safeRuntimeConfig?: ValidationOptions
+  }
+  interface NitroOptions {
+    safeRuntimeConfig?: ValidationOptions
+  }
+}
+
 export interface EnvVar {
   key: string
   value: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,19 @@ import type { StandardJSONSchemaV1, StandardSchemaV1 } from '@standard-schema/sp
 
 export type ErrorBehavior = 'throw' | 'warn' | 'ignore'
 
+export interface ValidationOptions {
+  /** Standard Schema for validation (Zod, Valibot, ArkType, etc.) */
+  $schema?: StandardSchemaV1
+  /** Validate runtime config at build time. Default: true */
+  validateAtBuild?: boolean
+  /** Validate runtime config at runtime via Nitro plugin. Default: false */
+  validateAtRuntime?: boolean
+  /** JSON Schema target version. Default: 'draft-2020-12' */
+  jsonSchemaTarget?: StandardJSONSchemaV1.Target
+  /** Behavior when validation fails. Default: 'throw' */
+  onError?: ErrorBehavior
+}
+
 export interface ShelveProviderOptions {
   /** Enable Shelve integration. Default: false */
   enabled?: boolean
@@ -21,17 +34,7 @@ export interface ShelveProviderOptions {
   fetchAtRuntime?: boolean
 }
 
-export interface ModuleOptions {
-  /** Standard Schema for validation (Zod, Valibot, ArkType, etc.) */
-  $schema?: StandardSchemaV1
-  /** Validate runtime config at build time. Default: true */
-  validateAtBuild?: boolean
-  /** Validate runtime config at runtime via Nitro plugin. Default: false */
-  validateAtRuntime?: boolean
-  /** JSON Schema target version. Default: 'draft-2020-12' */
-  jsonSchemaTarget?: StandardJSONSchemaV1.Target
-  /** Behavior when validation fails. Default: 'throw' */
-  onError?: ErrorBehavior
+export interface ModuleOptions extends ValidationOptions {
   /** Shelve integration options */
   shelve?: boolean | ShelveProviderOptions
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,3 +1,4 @@
+import type { SchemaDraft } from '@cfworker/json-schema'
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from '@standard-schema/spec'
 import type { ErrorBehavior, ValidationOptions } from './types'
 import { generateTypeDeclaration } from './json-schema-to-ts'
@@ -18,7 +19,7 @@ export interface ValidationLogger {
 }
 
 export interface RuntimeValidationArtifacts {
-  draft: string
+  draft: SchemaDraft
   jsonSchema: Record<string, unknown>
   typeDeclaration: string
   validateTemplate: string
@@ -35,9 +36,7 @@ export function resolveValidationOptions(options: ValidationOptions = {}): Resol
   }
 }
 
-export function detectJsonSchemaDraft(schemaUri: string | undefined): string {
-  if (schemaUri?.includes('2020-12'))
-    return '2020-12'
+export function detectJsonSchemaDraft(schemaUri: string | undefined): SchemaDraft {
   if (schemaUri?.includes('2019-09'))
     return '2019-09'
   if (schemaUri?.includes('draft-07'))
@@ -60,8 +59,17 @@ export async function createRuntimeValidationArtifacts(
     jsonSchema,
     typeDeclaration: generateTypeDeclaration(jsonSchema),
     validateTemplate: `export const schema = ${JSON.stringify(jsonSchema)}\nexport const onError = ${JSON.stringify(options.onError)}\nexport const draft = ${JSON.stringify(draft)}\n`,
-    validateTemplateDeclaration: `export declare const schema: Record<string, unknown>\nexport declare const onError: 'throw' | 'warn' | 'ignore'\nexport declare const draft: string\n`,
+    validateTemplateDeclaration: `import type { Schema, SchemaDraft } from '@cfworker/json-schema'\nexport declare const schema: Schema\nexport declare const onError: 'throw' | 'warn' | 'ignore'\nexport declare const draft: SchemaDraft\n`,
   }
+}
+
+function reportError(msg: string, onError: ErrorBehavior, logger: ValidationLogger, throwMsg?: string): void {
+  if (onError === 'throw') {
+    logger.error(msg)
+    throw new Error(throwMsg ?? msg)
+  }
+  if (onError === 'warn')
+    logger.warn(msg)
 }
 
 export async function validateRuntimeConfig(
@@ -71,14 +79,7 @@ export async function validateRuntimeConfig(
   logger: ValidationLogger,
 ): Promise<void> {
   if (!isStandardSchema(schema)) {
-    const msg = 'Schema is not Standard Schema compatible'
-    if (onError === 'throw') {
-      logger.error(msg)
-      throw new Error('Invalid schema format')
-    }
-    else if (onError === 'warn') {
-      logger.warn(msg)
-    }
+    reportError('Schema is not Standard Schema compatible', onError, logger, 'Invalid schema format')
     return
   }
 
@@ -86,13 +87,7 @@ export async function validateRuntimeConfig(
 
   if ('issues' in result && result.issues && result.issues.length > 0) {
     const errorLines = result.issues.map((issue, index) => `  ${index + 1}. ${formatIssue(issue)}`)
-    if (onError === 'throw') {
-      logger.error(`Validation failed!\n${errorLines.join('\n')}`)
-      throw new Error('Runtime config validation failed')
-    }
-    else if (onError === 'warn') {
-      logger.warn(`Validation failed!\n${errorLines.join('\n')}`)
-    }
+    reportError(`Validation failed!\n${errorLines.join('\n')}`, onError, logger, 'Runtime config validation failed')
     return
   }
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,118 @@
+import type { StandardJSONSchemaV1, StandardSchemaV1 } from '@standard-schema/spec'
+import type { ErrorBehavior, ValidationOptions } from './types'
+import { generateTypeDeclaration } from './json-schema-to-ts'
+import { getJSONSchema } from './utils/json-schema'
+
+export interface ResolvedValidationOptions {
+  $schema?: StandardSchemaV1
+  validateAtBuild: boolean
+  validateAtRuntime: boolean
+  jsonSchemaTarget: StandardJSONSchemaV1.Target
+  onError: ErrorBehavior
+}
+
+export interface ValidationLogger {
+  error: (message: string) => void
+  warn: (message: string) => void
+  success: (message: string) => void
+}
+
+export interface RuntimeValidationArtifacts {
+  draft: string
+  jsonSchema: Record<string, unknown>
+  typeDeclaration: string
+  validateTemplate: string
+  validateTemplateDeclaration: string
+}
+
+export function resolveValidationOptions(options: ValidationOptions = {}): ResolvedValidationOptions {
+  return {
+    $schema: options.$schema,
+    validateAtBuild: options.validateAtBuild ?? true,
+    validateAtRuntime: options.validateAtRuntime ?? false,
+    jsonSchemaTarget: options.jsonSchemaTarget ?? 'draft-2020-12',
+    onError: options.onError ?? 'throw',
+  }
+}
+
+export function detectJsonSchemaDraft(schemaUri: string | undefined): string {
+  if (schemaUri?.includes('2020-12'))
+    return '2020-12'
+  if (schemaUri?.includes('2019-09'))
+    return '2019-09'
+  if (schemaUri?.includes('draft-07'))
+    return '7'
+  return '2020-12'
+}
+
+export async function createRuntimeValidationArtifacts(
+  options: ResolvedValidationOptions,
+  warn: (message: string) => void,
+): Promise<RuntimeValidationArtifacts | null> {
+  if (!options.$schema)
+    return null
+
+  const jsonSchema = await getJSONSchema(options.$schema, options.jsonSchemaTarget, warn)
+  const draft = detectJsonSchemaDraft(jsonSchema.$schema as string | undefined)
+
+  return {
+    draft,
+    jsonSchema,
+    typeDeclaration: generateTypeDeclaration(jsonSchema),
+    validateTemplate: `export const schema = ${JSON.stringify(jsonSchema)}\nexport const onError = ${JSON.stringify(options.onError)}\nexport const draft = ${JSON.stringify(draft)}\n`,
+    validateTemplateDeclaration: `export declare const schema: Record<string, unknown>\nexport declare const onError: 'throw' | 'warn' | 'ignore'\nexport declare const draft: string\n`,
+  }
+}
+
+export async function validateRuntimeConfig(
+  config: unknown,
+  schema: StandardSchemaV1,
+  onError: ErrorBehavior,
+  logger: ValidationLogger,
+): Promise<void> {
+  if (!isStandardSchema(schema)) {
+    const msg = 'Schema is not Standard Schema compatible'
+    if (onError === 'throw') {
+      logger.error(msg)
+      throw new Error('Invalid schema format')
+    }
+    else if (onError === 'warn') {
+      logger.warn(msg)
+    }
+    return
+  }
+
+  const result = await schema['~standard'].validate(config)
+
+  if ('issues' in result && result.issues && result.issues.length > 0) {
+    const errorLines = result.issues.map((issue, index) => `  ${index + 1}. ${formatIssue(issue)}`)
+    if (onError === 'throw') {
+      logger.error(`Validation failed!\n${errorLines.join('\n')}`)
+      throw new Error('Runtime config validation failed')
+    }
+    else if (onError === 'warn') {
+      logger.warn(`Validation failed!\n${errorLines.join('\n')}`)
+    }
+    return
+  }
+
+  logger.success('Validated Runtime Config')
+}
+
+function isStandardSchema(schema: unknown): schema is StandardSchemaV1 {
+  const candidate = schema as { '~standard'?: { validate?: unknown } } | null | undefined
+  return Boolean(
+    candidate
+    && (typeof schema === 'object' || typeof schema === 'function')
+    && candidate['~standard']
+    && typeof candidate['~standard'] === 'object'
+    && typeof candidate['~standard'].validate === 'function',
+  )
+}
+
+function formatIssue(issue: { path?: ReadonlyArray<PropertyKey | { key: PropertyKey }>, message?: string }): string {
+  const path = issue.path
+    ? issue.path.map(p => typeof p === 'object' && p !== null && 'key' in p ? p.key : p).join('.')
+    : 'root'
+  return `${path}: ${issue.message || 'Validation error'}`
+}

--- a/test/fixtures/_shared/nitro-runtime-config-schema.ts
+++ b/test/fixtures/_shared/nitro-runtime-config-schema.ts
@@ -1,0 +1,18 @@
+import { number, object, string } from 'valibot'
+
+export const runtimeConfigSchema = object({
+  port: number(),
+  secretKey: string(),
+  public: object({ apiBase: string() }),
+})
+
+export const validRuntimeConfig = {
+  port: 3000,
+  secretKey: 'test-secret',
+  public: { apiBase: 'https://api.example.com' },
+}
+
+export const invalidRuntimeConfig = {
+  ...validRuntimeConfig,
+  port: 'not-a-number',
+}

--- a/test/fixtures/nitro-runtime-invalid/nitro.config.ts
+++ b/test/fixtures/nitro-runtime-invalid/nitro.config.ts
@@ -1,23 +1,9 @@
 import { defineNitroConfig } from 'nitropack/config'
-import { number, object, string } from 'valibot'
 import SafeRuntimeConfig from '../../../src/nitro'
-
-const runtimeConfigSchema = object({
-  port: number(),
-  secretKey: string(),
-  public: object({ apiBase: string() }),
-})
+import { invalidRuntimeConfig, runtimeConfigSchema } from '../_shared/nitro-runtime-config-schema'
 
 export default defineNitroConfig({
   modules: [SafeRuntimeConfig],
-  runtimeConfig: {
-    port: 'not-a-number',
-    secretKey: 'test-secret',
-    public: { apiBase: 'https://api.example.com' },
-  },
-  safeRuntimeConfig: {
-    $schema: runtimeConfigSchema,
-    validateAtBuild: false,
-    validateAtRuntime: true,
-  },
+  runtimeConfig: invalidRuntimeConfig,
+  safeRuntimeConfig: { $schema: runtimeConfigSchema, validateAtBuild: false, validateAtRuntime: true },
 })

--- a/test/fixtures/nitro-runtime-invalid/nitro.config.ts
+++ b/test/fixtures/nitro-runtime-invalid/nitro.config.ts
@@ -1,0 +1,23 @@
+import { defineNitroConfig } from 'nitropack/config'
+import { number, object, string } from 'valibot'
+import SafeRuntimeConfig from '../../../src/nitro'
+
+const runtimeConfigSchema = object({
+  port: number(),
+  secretKey: string(),
+  public: object({ apiBase: string() }),
+})
+
+export default defineNitroConfig({
+  modules: [SafeRuntimeConfig],
+  runtimeConfig: {
+    port: 'not-a-number',
+    secretKey: 'test-secret',
+    public: { apiBase: 'https://api.example.com' },
+  },
+  safeRuntimeConfig: {
+    $schema: runtimeConfigSchema,
+    validateAtBuild: false,
+    validateAtRuntime: true,
+  },
+})

--- a/test/fixtures/nitro-runtime-invalid/nitro.config.ts
+++ b/test/fixtures/nitro-runtime-invalid/nitro.config.ts
@@ -1,4 +1,4 @@
-import { defineNitroConfig } from 'nitropack/config'
+import { defineNitroConfig } from 'nitro/config'
 import SafeRuntimeConfig from '../../../src/nitro'
 import { invalidRuntimeConfig, runtimeConfigSchema } from '../_shared/nitro-runtime-config-schema'
 

--- a/test/fixtures/nitro-validation-failure/nitro.config.ts
+++ b/test/fixtures/nitro-validation-failure/nitro.config.ts
@@ -1,0 +1,21 @@
+import { defineNitroConfig } from 'nitropack/config'
+import { number, object, string } from 'valibot'
+import SafeRuntimeConfig from '../../../src/nitro'
+
+const runtimeConfigSchema = object({
+  port: number(),
+  secretKey: string(),
+  public: object({ apiBase: string() }),
+})
+
+export default defineNitroConfig({
+  modules: [SafeRuntimeConfig],
+  runtimeConfig: {
+    port: 'not-a-number',
+    secretKey: 'test-secret',
+    public: { apiBase: 'https://api.example.com' },
+  },
+  safeRuntimeConfig: {
+    $schema: runtimeConfigSchema,
+  },
+})

--- a/test/fixtures/nitro-validation-failure/nitro.config.ts
+++ b/test/fixtures/nitro-validation-failure/nitro.config.ts
@@ -1,21 +1,9 @@
 import { defineNitroConfig } from 'nitropack/config'
-import { number, object, string } from 'valibot'
 import SafeRuntimeConfig from '../../../src/nitro'
-
-const runtimeConfigSchema = object({
-  port: number(),
-  secretKey: string(),
-  public: object({ apiBase: string() }),
-})
+import { invalidRuntimeConfig, runtimeConfigSchema } from '../_shared/nitro-runtime-config-schema'
 
 export default defineNitroConfig({
   modules: [SafeRuntimeConfig],
-  runtimeConfig: {
-    port: 'not-a-number',
-    secretKey: 'test-secret',
-    public: { apiBase: 'https://api.example.com' },
-  },
-  safeRuntimeConfig: {
-    $schema: runtimeConfigSchema,
-  },
+  runtimeConfig: invalidRuntimeConfig,
+  safeRuntimeConfig: { $schema: runtimeConfigSchema },
 })

--- a/test/fixtures/nitro-validation-failure/nitro.config.ts
+++ b/test/fixtures/nitro-validation-failure/nitro.config.ts
@@ -1,4 +1,4 @@
-import { defineNitroConfig } from 'nitropack/config'
+import { defineNitroConfig } from 'nitro/config'
 import SafeRuntimeConfig from '../../../src/nitro'
 import { invalidRuntimeConfig, runtimeConfigSchema } from '../_shared/nitro-runtime-config-schema'
 

--- a/test/fixtures/nitro-validation-success/nitro.config.ts
+++ b/test/fixtures/nitro-validation-success/nitro.config.ts
@@ -1,4 +1,4 @@
-import { defineNitroConfig } from 'nitropack/config'
+import { defineNitroConfig } from 'nitro/config'
 import SafeRuntimeConfig from '../../../src/nitro'
 import { runtimeConfigSchema, validRuntimeConfig } from '../_shared/nitro-runtime-config-schema'
 

--- a/test/fixtures/nitro-validation-success/nitro.config.ts
+++ b/test/fixtures/nitro-validation-success/nitro.config.ts
@@ -1,22 +1,9 @@
 import { defineNitroConfig } from 'nitropack/config'
-import { number, object, string } from 'valibot'
 import SafeRuntimeConfig from '../../../src/nitro'
-
-const runtimeConfigSchema = object({
-  port: number(),
-  secretKey: string(),
-  public: object({ apiBase: string() }),
-})
+import { runtimeConfigSchema, validRuntimeConfig } from '../_shared/nitro-runtime-config-schema'
 
 export default defineNitroConfig({
   modules: [SafeRuntimeConfig],
-  runtimeConfig: {
-    port: 3000,
-    secretKey: 'test-secret',
-    public: { apiBase: 'https://api.example.com' },
-  },
-  safeRuntimeConfig: {
-    $schema: runtimeConfigSchema,
-    validateAtRuntime: true,
-  },
+  runtimeConfig: validRuntimeConfig,
+  safeRuntimeConfig: { $schema: runtimeConfigSchema, validateAtRuntime: true },
 })

--- a/test/fixtures/nitro-validation-success/nitro.config.ts
+++ b/test/fixtures/nitro-validation-success/nitro.config.ts
@@ -1,0 +1,22 @@
+import { defineNitroConfig } from 'nitropack/config'
+import { number, object, string } from 'valibot'
+import SafeRuntimeConfig from '../../../src/nitro'
+
+const runtimeConfigSchema = object({
+  port: number(),
+  secretKey: string(),
+  public: object({ apiBase: string() }),
+})
+
+export default defineNitroConfig({
+  modules: [SafeRuntimeConfig],
+  runtimeConfig: {
+    port: 3000,
+    secretKey: 'test-secret',
+    public: { apiBase: 'https://api.example.com' },
+  },
+  safeRuntimeConfig: {
+    $schema: runtimeConfigSchema,
+    validateAtRuntime: true,
+  },
+})

--- a/test/fixtures/nitro-validation-success/server/api/config.get.ts
+++ b/test/fixtures/nitro-validation-success/server/api/config.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(() => {
+  const config = useRuntimeConfig()
+  return { port: config.port }
+})

--- a/test/nitro.test.ts
+++ b/test/nitro.test.ts
@@ -1,0 +1,72 @@
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const nitroBin = fileURLToPath(new URL('../node_modules/.bin/nitro', import.meta.url))
+
+function fixturePath(name: string): string {
+  return fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url))
+}
+
+function runNitroBuild(fixtureDir: string) {
+  return spawnSync(nitroBin, ['build'], {
+    cwd: fixtureDir,
+    encoding: 'utf8',
+    env: process.env,
+  })
+}
+
+describe('nitro module', () => {
+  it('validates build config and generates runtime validation files', () => {
+    const fixtureDir = fixturePath('nitro-validation-success')
+    const result = runNitroBuild(fixtureDir)
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0)
+    expect(existsSync(join(fixtureDir, '.nitro/safe-runtime-config/validate.mjs'))).toBe(true)
+    expect(existsSync(join(fixtureDir, '.nitro/types/safe-runtime-config.d.ts'))).toBe(true)
+
+    const validateModule = readFileSync(join(fixtureDir, '.nitro/safe-runtime-config/validate.mjs'), 'utf8')
+    expect(validateModule).toContain('export const schema')
+    expect(validateModule).toContain('export const onError')
+  }, 60000)
+
+  it('fails during build when runtime config does not match the schema', () => {
+    const fixtureDir = fixturePath('nitro-validation-failure')
+    const result = runNitroBuild(fixtureDir)
+
+    expect(result.status).not.toBe(0)
+    expect(`${result.stdout}\n${result.stderr}`).toContain('Runtime config validation failed')
+  }, 60000)
+
+  it('fails at runtime when runtime validation is enabled', async () => {
+    const fixtureDir = fixturePath('nitro-runtime-invalid')
+    const build = runNitroBuild(fixtureDir)
+    expect(build.status, `${build.stdout}\n${build.stderr}`).toBe(0)
+
+    const output = await new Promise<string>((resolve) => {
+      let logs = ''
+      const child = spawn('node', [join(fixtureDir, '.output/server/index.mjs')], {
+        cwd: fixtureDir,
+        env: { ...process.env, PORT: '48766' },
+      })
+
+      child.stderr.on('data', (data) => {
+        logs += data.toString()
+      })
+      child.stdout.on('data', (data) => {
+        logs += data.toString()
+      })
+      child.on('exit', () => resolve(logs))
+
+      setTimeout(() => {
+        child.kill()
+        resolve(logs)
+      }, 3000)
+    })
+
+    expect(output).toContain('Runtime validation failed')
+    expect(output).toContain('port')
+  }, 60000)
+})

--- a/test/nitro.test.ts
+++ b/test/nitro.test.ts
@@ -15,6 +15,10 @@ function runNitroBuild(fixtureDir: string) {
   return spawnSync(nitroBin, ['build'], { cwd: fixtureDir, encoding: 'utf8', env: process.env })
 }
 
+function firstExisting(paths: string[]): string | undefined {
+  return paths.find(path => existsSync(path))
+}
+
 function waitForOutputMatching(child: ReturnType<typeof spawn>, pattern: RegExp, timeoutMs: number): Promise<string> {
   return new Promise((resolve) => {
     let logs = ''
@@ -40,10 +44,19 @@ describe('nitro module', () => {
     const result = runNitroBuild(fixtureDir)
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0)
-    expect(existsSync(join(fixtureDir, '.nitro/safe-runtime-config/validate.mjs'))).toBe(true)
-    expect(existsSync(join(fixtureDir, '.nitro/types/safe-runtime-config.d.ts'))).toBe(true)
+    const validateModulePath = firstExisting([
+      join(fixtureDir, '.nitro/safe-runtime-config/validate.mjs'),
+      join(fixtureDir, 'node_modules/.nitro/safe-runtime-config/validate.mjs'),
+    ])
+    const typeDeclarationPath = firstExisting([
+      join(fixtureDir, '.nitro/types/safe-runtime-config.d.ts'),
+      join(fixtureDir, 'node_modules/.nitro/types/safe-runtime-config.d.ts'),
+    ])
 
-    const validateModule = readFileSync(join(fixtureDir, '.nitro/safe-runtime-config/validate.mjs'), 'utf8')
+    expect(validateModulePath).toBeDefined()
+    expect(typeDeclarationPath).toBeDefined()
+
+    const validateModule = readFileSync(validateModulePath!, 'utf8')
     expect(validateModule).toContain('export const schema')
     expect(validateModule).toContain('export const onError')
   }, 60000)

--- a/test/nitro.test.ts
+++ b/test/nitro.test.ts
@@ -1,3 +1,4 @@
+import type { Buffer } from 'node:buffer'
 import { spawn, spawnSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -11,15 +12,30 @@ function fixturePath(name: string): string {
 }
 
 function runNitroBuild(fixtureDir: string) {
-  return spawnSync(nitroBin, ['build'], {
-    cwd: fixtureDir,
-    encoding: 'utf8',
-    env: process.env,
+  return spawnSync(nitroBin, ['build'], { cwd: fixtureDir, encoding: 'utf8', env: process.env })
+}
+
+function waitForOutputMatching(child: ReturnType<typeof spawn>, pattern: RegExp, timeoutMs: number): Promise<string> {
+  return new Promise((resolve) => {
+    let logs = ''
+    const finish = () => {
+      child.kill()
+      resolve(logs)
+    }
+    const onData = (data: Buffer) => {
+      logs += data.toString()
+      if (pattern.test(logs))
+        finish()
+    }
+    child.stdout?.on('data', onData)
+    child.stderr?.on('data', onData)
+    child.on('exit', () => resolve(logs))
+    setTimeout(finish, timeoutMs)
   })
 }
 
 describe('nitro module', () => {
-  it('validates build config and generates runtime validation files', () => {
+  it.concurrent('validates build config and generates runtime validation files', () => {
     const fixtureDir = fixturePath('nitro-validation-success')
     const result = runNitroBuild(fixtureDir)
 
@@ -32,7 +48,7 @@ describe('nitro module', () => {
     expect(validateModule).toContain('export const onError')
   }, 60000)
 
-  it('fails during build when runtime config does not match the schema', () => {
+  it.concurrent('fails during build when runtime config does not match the schema', () => {
     const fixtureDir = fixturePath('nitro-validation-failure')
     const result = runNitroBuild(fixtureDir)
 
@@ -40,31 +56,16 @@ describe('nitro module', () => {
     expect(`${result.stdout}\n${result.stderr}`).toContain('Runtime config validation failed')
   }, 60000)
 
-  it('fails at runtime when runtime validation is enabled', async () => {
+  it.concurrent('fails at runtime when runtime validation is enabled', async () => {
     const fixtureDir = fixturePath('nitro-runtime-invalid')
     const build = runNitroBuild(fixtureDir)
     expect(build.status, `${build.stdout}\n${build.stderr}`).toBe(0)
 
-    const output = await new Promise<string>((resolve) => {
-      let logs = ''
-      const child = spawn('node', [join(fixtureDir, '.output/server/index.mjs')], {
-        cwd: fixtureDir,
-        env: { ...process.env, PORT: '48766' },
-      })
-
-      child.stderr.on('data', (data) => {
-        logs += data.toString()
-      })
-      child.stdout.on('data', (data) => {
-        logs += data.toString()
-      })
-      child.on('exit', () => resolve(logs))
-
-      setTimeout(() => {
-        child.kill()
-        resolve(logs)
-      }, 3000)
+    const child = spawn('node', [join(fixtureDir, '.output/server/index.mjs')], {
+      cwd: fixtureDir,
+      env: { ...process.env, PORT: '48766' },
     })
+    const output = await waitForOutputMatching(child, /Runtime validation failed/, 5000)
 
     expect(output).toContain('Runtime validation failed')
     expect(output).toContain('port')

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -59,6 +59,14 @@ describe('build-time validation', () => {
     })
     expect(true).toBe(true)
   }, 30000)
+
+  it('does not validate during prepare', () => {
+    const fixtureDir = fileURLToPath(new URL('./fixtures/validation-failure', import.meta.url))
+
+    execSync('pnpm nuxi prepare', { cwd: fixtureDir, stdio: 'pipe' })
+
+    expect(existsSync(join(fixtureDir, '.nuxt'))).toBe(true)
+  }, 30000)
 })
 
 describe('runtime JSON Schema generation', () => {

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,26 +1,46 @@
-import { execSync } from 'node:child_process'
+import { execSync, spawnSync } from 'node:child_process'
 import { existsSync, readFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { fileURLToPath } from 'node:url'
 import { setup } from '@nuxt/test-utils/e2e'
+import { number, object, optional, string } from 'valibot'
 import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { createRuntimeValidationArtifacts, resolveValidationOptions } from '../src/validation'
 
-async function loadRuntimeValidationTemplate(fixtureDir: string) {
-  rmSync(join(fixtureDir, '.nuxt/safe-runtime-config'), { recursive: true, force: true })
-  execSync('pnpm nuxi prepare', { cwd: fixtureDir, stdio: 'pipe' })
+const zodRuntimeConfigSchema = z.object({
+  public: z.object({
+    apiBase: z.string(),
+  }),
+  secretKey: z.string(),
+})
 
-  const templatePath = join(fixtureDir, '.nuxt/safe-runtime-config/validate.mjs')
-  const declarationPath = join(fixtureDir, '.nuxt/safe-runtime-config/validate.d.ts')
+const valibotRuntimeConfigSchema = object({
+  public: object({
+    apiBase: string(),
+  }),
+  secretKey: string(),
+  port: optional(number()),
+})
 
-  expect(existsSync(templatePath)).toBe(true)
-  expect(existsSync(declarationPath)).toBe(true)
+function cleanNuxtBuildOutputs(fixtureDir: string): void {
+  rmSync(join(fixtureDir, '.nuxt'), { recursive: true, force: true })
+  rmSync(join(fixtureDir, '.output'), { recursive: true, force: true })
+  rmSync(join(fixtureDir, 'node_modules/.cache/nuxt'), { recursive: true, force: true })
+}
 
-  const template = await import(`${pathToFileURL(templatePath).href}?t=${Date.now()}-${Math.random()}`)
+async function createRuntimeValidationTemplate($schema: Parameters<typeof resolveValidationOptions>[0]['$schema']) {
+  const artifacts = await createRuntimeValidationArtifacts(
+    resolveValidationOptions({ $schema, validateAtRuntime: true }),
+    () => {},
+  )
 
-  return template as {
-    schema: Record<string, any>
-    onError: 'throw' | 'warn' | 'ignore'
-    draft: string
+  expect(artifacts).not.toBeNull()
+
+  return {
+    draft: artifacts!.draft,
+    onError: resolveValidationOptions({ $schema }).onError,
+    schema: artifacts!.jsonSchema,
   }
 }
 
@@ -67,12 +87,33 @@ describe('build-time validation', () => {
 
     expect(existsSync(join(fixtureDir, '.nuxt'))).toBe(true)
   }, 30000)
+
+  it('fails Nuxt build validation through the Nitro module', () => {
+    const fixtureDir = fileURLToPath(new URL('./fixtures/validation-failure', import.meta.url))
+    cleanNuxtBuildOutputs(fixtureDir)
+
+    const result = spawnSync('pnpm', ['nuxi', 'build'], {
+      cwd: fixtureDir,
+      encoding: 'utf8',
+    })
+
+    expect(result.status).not.toBe(0)
+    expect(`${result.stdout}\n${result.stderr}`).toContain('Runtime config validation failed')
+  }, 60000)
 })
 
 describe('runtime JSON Schema generation', () => {
+  it('builds a Nuxt app with Nitro-owned runtime validation artifacts', () => {
+    const fixtureDir = fileURLToPath(new URL('./fixtures/runtime-invalid', import.meta.url))
+    cleanNuxtBuildOutputs(fixtureDir)
+
+    execSync('pnpm nuxi build', { cwd: fixtureDir, stdio: 'pipe' })
+
+    expect(existsSync(join(fixtureDir, '.output/server/index.mjs'))).toBe(true)
+  }, 60000)
+
   it('generates runtime validation template (Zod native)', async () => {
-    const fixtureDir = fileURLToPath(new URL('./fixtures/zod-native', import.meta.url))
-    const { draft, onError, schema } = await loadRuntimeValidationTemplate(fixtureDir)
+    const { draft, onError, schema } = await createRuntimeValidationTemplate(zodRuntimeConfigSchema)
 
     expect(schema).toHaveProperty('type', 'object')
     expect(schema).toHaveProperty('properties')
@@ -83,8 +124,7 @@ describe('runtime JSON Schema generation', () => {
   }, 30000)
 
   it('generates runtime validation template (Valibot fallback)', async () => {
-    const fixtureDir = fileURLToPath(new URL('./fixtures/valibot-runtime', import.meta.url))
-    const { draft, onError, schema } = await loadRuntimeValidationTemplate(fixtureDir)
+    const { draft, onError, schema } = await createRuntimeValidationTemplate(valibotRuntimeConfigSchema)
 
     expect(schema).toHaveProperty('type', 'object')
     expect(schema).toHaveProperty('properties')
@@ -94,8 +134,7 @@ describe('runtime JSON Schema generation', () => {
 
   it('zod native JSON Schema validates correctly', async () => {
     const { Validator } = await import('@cfworker/json-schema')
-    const fixtureDir = fileURLToPath(new URL('./fixtures/zod-native', import.meta.url))
-    const { draft, schema } = await loadRuntimeValidationTemplate(fixtureDir)
+    const { draft, schema } = await createRuntimeValidationTemplate(zodRuntimeConfigSchema)
 
     const validator = new Validator(schema, draft as any)
     const validConfig = { secretKey: 'test-key', public: { apiBase: 'https://api.test.com' } }
@@ -106,8 +145,7 @@ describe('runtime JSON Schema generation', () => {
 
   it('valibot fallback JSON Schema validates correctly', async () => {
     const { Validator } = await import('@cfworker/json-schema')
-    const fixtureDir = fileURLToPath(new URL('./fixtures/valibot-runtime', import.meta.url))
-    const { draft, schema } = await loadRuntimeValidationTemplate(fixtureDir)
+    const { draft, schema } = await createRuntimeValidationTemplate(valibotRuntimeConfigSchema)
 
     const validator = new Validator(schema, draft as any)
     const validConfig = { secretKey: 'test-key', public: { apiBase: 'https://api.test.com' } }

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,4 +1,4 @@
-import { execSync, spawn } from 'node:child_process'
+import { execSync } from 'node:child_process'
 import { existsSync, readFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -132,35 +132,5 @@ describe('runtime JSON Schema generation', () => {
       cwd: fixtureDir,
       stdio: 'pipe',
     })
-  }, 60000)
-})
-
-describe('runtime validation with env override', () => {
-  it('fails when env var overrides with invalid type', async () => {
-    const fixtureDir = fileURLToPath(new URL('./fixtures/valibot-runtime', import.meta.url))
-    execSync('pnpm nuxi build', { cwd: fixtureDir, stdio: 'pipe' })
-    const output = await new Promise<string>((resolve) => {
-      let stderr = ''
-      const serverPath = join(fixtureDir, '.output/server/index.mjs')
-      const child = spawn('node', [serverPath], {
-        cwd: fixtureDir,
-        env: { ...process.env, NUXT_PORT: 'not-a-number' },
-      })
-
-      child.stderr.on('data', (data) => {
-        stderr += data.toString()
-      })
-      child.stdout.on('data', (data) => {
-        stderr += data.toString()
-      })
-
-      setTimeout(() => {
-        child.kill()
-        resolve(stderr)
-      }, 3000)
-    })
-
-    expect(output).toContain('Runtime validation failed')
-    expect(output).toContain('port')
   }, 60000)
 })


### PR DESCRIPTION
Refactors runtime config validation around explicit `nuxt-safe-runtime-config/nitro` and `nuxt-safe-runtime-config/nuxt` package entries while keeping the root import as the backward-compatible Nuxt module.

The Nitro entry now owns build-time validation, runtime validation plugin registration, generated validation artifacts, and the thin Nitro v3/v2 runtime-config import fallback. The Nuxt adapter delegates validation into Nitro, keeps auto-imported `useSafeRuntimeConfig()` types, and leaves the existing Shelve integration on the Nuxt/root path only.

This also adds Nitro-only fixture coverage, Nuxt build regression coverage for Nitro-owned validation artifacts and build validation failures, and extends the packed-release smoke test with a Nitro consumer that imports `/nitro` without installing Nuxt. Docs now clarify that generated validation artifact paths are internal implementation details.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onmax/codesmith/nuxt-safe-runtime-config/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
