### PR TITLE
fix(nuxt): avoid external nitropack runtime barrel

### DIFF
--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -33,7 +33,7 @@ function resolveRuntimePlugin(): string {
 export const RUNTIME_PLUGIN_PATH = resolveRuntimePlugin()
 
 export function resolveRuntimeConfigImport(frameworkName = 'nitro'): string {
-  return frameworkName === 'nitro' ? 'nitro/runtime-config' : 'nitropack/runtime'
+  return frameworkName === 'nitro' ? 'nitro/runtime-config' : 'nitropack/runtime/config'
 }
 
 async function writeFileIfChanged(file: string, contents: string): Promise<void> {

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -109,7 +109,13 @@ describe('runtime JSON Schema generation', () => {
 
     execSync('pnpm nuxi build', { cwd: fixtureDir, stdio: 'pipe' })
 
-    expect(existsSync(join(fixtureDir, '.output/server/index.mjs'))).toBe(true)
+    const serverEntry = join(fixtureDir, '.output/server/index.mjs')
+    const nitroChunk = join(fixtureDir, '.output/server/chunks/nitro/nitro.mjs')
+    expect(existsSync(serverEntry)).toBe(true)
+
+    const serverOutput = `${readFileSync(serverEntry, 'utf-8')}\n${readFileSync(nitroChunk, 'utf-8')}`
+    expect(serverOutput).not.toContain('nitropack/runtime')
+    expect(serverOutput).not.toContain('#nitro-internal-virtual')
   }, 60000)
 
   it('generates runtime validation template (Zod native)', async () => {


### PR DESCRIPTION
Narrows the Nuxt runtime config import used by the Nitro validation plugin from the broad `nitropack/runtime` barrel to the config-only runtime entry. This keeps Nuxt node-server output from retaining a live package-runtime import that can pull Nitro virtual imports outside the generated Nitro build context.

Adds regression coverage that builds the Nuxt runtime-validation fixture and asserts the generated server output does not contain `nitropack/runtime` or `#nitro-internal-virtual` imports. Standalone Nitro keeps using `nitro/runtime-config`.